### PR TITLE
Fixed build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,16 @@ wayle config set general.theme dark
 
 ## Building
 
+Switch to nightly Rust:
 ```bash
-git clone https://github.com/username/wayle
+rustup toolchain install nightly
+rustup default nightly
+```
+Then clone the repository and build:
+```bash
+git clone https://github.com/Jas-SinghFSU/wayle
 cd wayle
-cargo install --path .
+cargo build
 ```
 
 ## License


### PR DESCRIPTION
- The clone link was wrong so I fixed that.
- Without nightly Rust, I kept getting error E0658, so I added instructions to switch to nightly Rust.
- The `cd wayle` command only moves us to the root directory, not the directory that contains the package manifest (`wayle/wayle`), so I fixed the install command to account for that.