### PR TITLE
wayle-cava: look for `cava.pc` instead of `libcava.pc`

### DIFF
--- a/crates/wayle-cava/build.rs
+++ b/crates/wayle-cava/build.rs
@@ -25,7 +25,7 @@ fn main() {
 #[cfg(not(feature = "vendored"))]
 fn build_system() -> Vec<PathBuf> {
     let lib =
-        pkg_config::probe_library("libcava").unwrap_or_else(|e| panic!("libcava not found: {e}"));
+        pkg_config::probe_library("cava").unwrap_or_else(|e| panic!("libcava not found: {e}"));
 
     println!("cargo:rustc-env=LIBCAVA_VERSION={}", lib.version);
     println!("cargo:rustc-link-lib=cava");


### PR DESCRIPTION
At least on NixOS it is named `cava.pc`, not `libcava.pc`

```
❯ lt /nix/store/njg87lwpv8r6b3496qsbcxbfxjq63zj1-libcava-0.10.6/
dr-xr-xr-x    - root  1 Jan  1970 /nix/store/njg87lwpv8r6b3496qsbcxbfxjq63zj1-libcava-0.10.6
dr-xr-xr-x    - root  1 Jan  1970 ├── include
dr-xr-xr-x    - root  1 Jan  1970 │   └── cava
.r--r--r-- 4.8k root  1 Jan  1970 │       ├── cavacore.h
.r--r--r--  141 root  1 Jan  1970 │       ├── common.h
.r--r--r-- 3.2k root  1 Jan  1970 │       ├── config.h
.r--r--r--  313 root  1 Jan  1970 │       ├── debug.h
dr-xr-xr-x    - root  1 Jan  1970 │       ├── input
.r--r--r-- 1.7k root  1 Jan  1970 │       │   └── common.h
dr-xr-xr-x    - root  1 Jan  1970 │       ├── output
.r--r--r-- 1.3k root  1 Jan  1970 │       │   ├── common.h
.r--r--r--  335 root  1 Jan  1970 │       │   ├── noritake.h
.r--r--r--  371 root  1 Jan  1970 │       │   ├── raw.h
.r--r--r--  214 root  1 Jan  1970 │       │   ├── terminal_bcircle.h
.r--r--r--  699 root  1 Jan  1970 │       │   ├── terminal_ncurses.h
.r--r--r--  973 root  1 Jan  1970 │       │   └── terminal_noncurses.h
.r--r--r--  644 root  1 Jan  1970 │       └── util.h
dr-xr-xr-x    - root  1 Jan  1970 └── lib
.r-xr-xr-x 150k root  1 Jan  1970     ├── libcava.so
dr-xr-xr-x    - root  1 Jan  1970     └── pkgconfig
.r--r--r--  284 root  1 Jan  1970         └── cava.pc # <======
```