### PR TITLE
fix: also load icons from filepaths for the systray

### DIFF
--- a/crates/wayle-shell/src/shell/bar/modules/systray/item/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/systray/item/mod.rs
@@ -3,9 +3,9 @@ mod watchers;
 
 use std::sync::Arc;
 
-use gtk4::gio::SimpleActionGroup;
 #[allow(deprecated)]
 use gtk4::prelude::StyleContextExt;
+use gtk4::{gdk, gio::SimpleActionGroup};
 use helpers::{create_texture_from_pixmap, load_icon_from_theme_path, select_best_pixmap};
 use relm4::{
     gtk::{self, prelude::*},
@@ -349,6 +349,10 @@ impl SystrayItem {
                 .as_deref()
                 .and_then(|p| load_icon_from_theme_path(p, name))
             {
+                image.set_paintable(Some(&texture));
+                return;
+            }
+            if let Ok(texture) = gdk::Texture::from_filename(name) {
                 image.set_paintable(Some(&texture));
                 return;
             }


### PR DESCRIPTION
Some applications provide icon data through a direct file path. This PR adds support for this.

If you want to deal with this differently, please let me know!