### PR TITLE
feat(shell): add VPN tunnel UI for WireGuard connections

### DIFF
--- a/crates/wayle-config/src/schemas/modules/network/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/network/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use schemars::schema_for;
 use wayle_derive::wayle_config;
 
@@ -127,6 +129,19 @@ pub struct NetworkConfig {
     #[serde(rename = "scroll-down")]
     #[default(ClickAction::None)]
     pub scroll_down: ConfigProperty<ClickAction>,
+
+    /// Custom display names for VPN tunnels, keyed by connection UUID.
+    ///
+    /// ## Examples
+    ///
+    /// ```toml
+    /// [modules.network.vpn-aliases]
+    /// "a1b2c3d4-e5f6-7890-abcd-ef1234567890" = "Work VPN"
+    /// "f0e1d2c3-b4a5-6789-0abc-def123456789" = "Home Server"
+    /// ```
+    #[serde(rename = "vpn-aliases")]
+    #[default(HashMap::new())]
+    pub vpn_aliases: ConfigProperty<HashMap<String, String>>,
 }
 
 impl ModuleInfoProvider for NetworkConfig {

--- a/crates/wayle-shell/locales/en-US/dropdowns/_network.ftl
+++ b/crates/wayle-shell/locales/en-US/dropdowns/_network.ftl
@@ -23,7 +23,7 @@ dropdown-network-no-adapter-description = No wireless adapter was detected on th
 ## VPN / WireGuard
 
 dropdown-network-wireguard-tunnels = WireGuard Tunnels
-dropdown-network-wireguard-import = Import
+dropdown-network-wireguard-import = Import WireGuard Configuration
 
 ## Security Types
 

--- a/crates/wayle-shell/locales/en-US/dropdowns/_network.ftl
+++ b/crates/wayle-shell/locales/en-US/dropdowns/_network.ftl
@@ -20,6 +20,11 @@ dropdown-network-no-networks-description = Make sure WiFi is enabled and try sca
 dropdown-network-no-adapter-title = No WiFi Adapter
 dropdown-network-no-adapter-description = No wireless adapter was detected on this system
 
+## VPN / WireGuard
+
+dropdown-network-wireguard-tunnels = WireGuard Tunnels
+dropdown-network-wireguard-import = Import
+
 ## Security Types
 
 dropdown-network-security-open = Open

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/available_networks/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/available_networks/mod.rs
@@ -83,15 +83,15 @@ impl Component for AvailableNetworks {
             Card {
                 add_css_class: "network-list",
                 set_overflow: gtk::Overflow::Hidden,
-                set_vexpand: true,
                 #[watch]
                 set_visible: model.wifi_available && !model.ap_cache.is_empty(),
 
                 #[name = "network_list_scroll"]
                 gtk::ScrolledWindow {
                     add_css_class: "network-list-scroll",
-                    set_vexpand: true,
                     set_hscrollbar_policy: gtk::PolicyType::Never,
+                    set_propagate_natural_height: true,
+                    set_max_content_height: 300,
 
                     #[local_ref]
                     network_list_widget -> gtk::Box {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/messages.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use wayle_config::ConfigService;
 use wayle_network::NetworkService;
 
-use super::available_networks::AvailableNetworksOutput;
+use super::{
+    available_networks::AvailableNetworksOutput,
+    vpn_tunnels::VpnTunnelsOutput,
+};
 
 pub(crate) struct NetworkDropdownInit {
     pub network: Arc<NetworkService>,
@@ -15,6 +18,7 @@ pub(crate) enum NetworkDropdownMsg {
     WifiToggled(bool),
     ScanRequested,
     AvailableNetworks(AvailableNetworksOutput),
+    VpnTunnels(VpnTunnelsOutput),
 }
 
 #[derive(Debug)]

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod helpers;
 mod messages;
 mod methods;
 mod password_form;
+mod vpn_tunnels;
 mod watchers;
 
 use std::sync::Arc;
@@ -21,6 +22,7 @@ use self::{
         AvailableNetworks, AvailableNetworksInit, AvailableNetworksInput, AvailableNetworksOutput,
     },
     messages::{NetworkDropdownCmd, NetworkDropdownInit, NetworkDropdownMsg},
+    vpn_tunnels::{VpnTunnels, VpnTunnelsInit},
 };
 use crate::{i18n::t, shell::bar::dropdowns::scaled_dimension};
 
@@ -35,6 +37,7 @@ pub(crate) struct NetworkDropdown {
     wifi_available: bool,
     scanning: bool,
     active_connections: Controller<ActiveConnections>,
+    vpn_tunnels: Controller<VpnTunnels>,
     available_networks: Controller<AvailableNetworks>,
     wifi_watcher: WatcherToken,
 }
@@ -120,6 +123,9 @@ impl Component for NetworkDropdown {
                     active_connections_widget -> gtk::Box {},
 
                     #[local_ref]
+                    vpn_tunnels_widget -> gtk::Box {},
+
+                    #[local_ref]
                     available_networks_widget -> gtk::Box {
                         set_vexpand: true,
                     },
@@ -138,6 +144,14 @@ impl Component for NetworkDropdown {
                 network: init.network.clone(),
             })
             .detach();
+
+        let vpn_tunnels = VpnTunnels::builder()
+            .launch(VpnTunnelsInit {
+                network: init.network.clone(),
+                config: init.config.clone(),
+                provider: vpn_tunnels::providers::wireguard_config(),
+            })
+            .forward(sender.input_sender(), NetworkDropdownMsg::VpnTunnels);
 
         let available_networks = AvailableNetworks::builder()
             .launch(AvailableNetworksInit {
@@ -161,6 +175,7 @@ impl Component for NetworkDropdown {
             wifi_available,
             scanning: false,
             active_connections,
+            vpn_tunnels,
             available_networks,
             wifi_watcher: WatcherToken::new(),
         };
@@ -168,6 +183,7 @@ impl Component for NetworkDropdown {
         model.reset_wifi_watchers(&sender);
 
         let active_connections_widget = model.active_connections.widget();
+        let vpn_tunnels_widget = model.vpn_tunnels.widget();
         let available_networks_widget = model.available_networks.widget();
         let widgets = view_output!();
 
@@ -182,6 +198,9 @@ impl Component for NetworkDropdown {
             NetworkDropdownMsg::ScanRequested => {
                 self.available_networks
                     .emit(AvailableNetworksInput::ScanRequested);
+            }
+            NetworkDropdownMsg::VpnTunnels(_output) => {
+                // VPN tunnel events are handled internally by the component
             }
             NetworkDropdownMsg::AvailableNetworks(output) => match output {
                 AvailableNetworksOutput::ScanStarted => {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/mod.rs
@@ -27,12 +27,10 @@ use self::{
 use crate::{i18n::t, shell::bar::dropdowns::scaled_dimension};
 
 const BASE_WIDTH: f32 = 382.0;
-const BASE_HEIGHT: f32 = 512.0;
 
 pub(crate) struct NetworkDropdown {
     network: Arc<NetworkService>,
     scaled_width: i32,
-    scaled_height: i32,
     wifi_enabled: bool,
     wifi_available: bool,
     scanning: bool,
@@ -56,8 +54,6 @@ impl Component for NetworkDropdown {
             set_has_arrow: false,
             #[watch]
             set_width_request: model.scaled_width,
-            #[watch]
-            set_height_request: model.scaled_height,
 
             #[template]
             Dropdown {
@@ -117,7 +113,6 @@ impl Component for NetworkDropdown {
                 #[template]
                 DropdownContent {
                     add_css_class: "network-content",
-                    set_vexpand: true,
 
                     #[local_ref]
                     active_connections_widget -> gtk::Box {},
@@ -126,9 +121,7 @@ impl Component for NetworkDropdown {
                     vpn_tunnels_widget -> gtk::Box {},
 
                     #[local_ref]
-                    available_networks_widget -> gtk::Box {
-                        set_vexpand: true,
-                    },
+                    available_networks_widget -> gtk::Box {},
                 },
             },
         }
@@ -170,7 +163,6 @@ impl Component for NetworkDropdown {
         let mut model = Self {
             network: init.network,
             scaled_width: scaled_dimension(BASE_WIDTH, scale),
-            scaled_height: scaled_dimension(BASE_HEIGHT, scale),
             wifi_enabled,
             wifi_available,
             scanning: false,
@@ -251,7 +243,6 @@ impl Component for NetworkDropdown {
         match msg {
             NetworkDropdownCmd::ScaleChanged(scale) => {
                 self.scaled_width = scaled_dimension(BASE_WIDTH, scale);
-                self.scaled_height = scaled_dimension(BASE_HEIGHT, scale);
             }
 
             NetworkDropdownCmd::WifiDeviceChanged => {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/messages.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use wayle_config::ConfigService;
+use wayle_network::NetworkService;
+use zbus::zvariant::OwnedObjectPath;
+
+/// UI-friendly snapshot of a VPN tunnel's current state.
+#[derive(Debug, Clone)]
+pub(crate) struct TunnelState {
+    pub uuid: String,
+    pub name: String,
+    pub active: bool,
+    /// Whether this tunnel is managed externally (e.g. by wg-quick)
+    /// rather than by NetworkManager. Externally managed tunnels
+    /// should not be toggled via NM as it can corrupt their config.
+    pub externally_managed: bool,
+    pub ip4_address: Option<String>,
+    pub interface_name: Option<String>,
+    pub connection_path: OwnedObjectPath,
+}
+
+/// Configuration for a specific VPN provider's UI presentation and behavior.
+///
+/// Each provider (WireGuard, OpenVPN, etc.) supplies one of these to
+/// customize the generic VPN tunnels component.
+pub(crate) struct VpnProviderConfig {
+    /// Localized section title (e.g., "WireGuard Tunnels").
+    pub section_label: String,
+    /// Fallback display name when a tunnel has no connection ID
+    /// (e.g., "WireGuard", "OpenVPN").
+    pub fallback_name: &'static str,
+    /// GTK icon name for tunnel cards.
+    pub icon: &'static str,
+    /// Glob pattern for the import file dialog (e.g., "*.conf").
+    pub import_filter: &'static str,
+    /// Human-readable label for the file filter (e.g., "WireGuard Config (*.conf)").
+    pub import_filter_label: &'static str,
+}
+
+pub(crate) struct VpnTunnelsInit {
+    pub network: Arc<NetworkService>,
+    pub config: Arc<ConfigService>,
+    pub provider: VpnProviderConfig,
+}
+
+#[derive(Debug)]
+pub(crate) enum VpnTunnelsInput {
+    /// Toggle tunnel (index, desired_active_state).
+    ToggleTunnel(usize, bool),
+    RenameTunnel(usize, String),
+    ImportConfig,
+    FileSelected(String, String),
+}
+
+#[derive(Debug)]
+pub(crate) enum VpnTunnelsCmd {
+    TunnelsChanged(Vec<TunnelState>),
+    ServiceChanged,
+    ToggleResult(usize, Result<(), String>),
+    ImportResult(Result<String, String>),
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum VpnTunnelsOutput {
+    Activated(String),
+    Deactivated(String),
+    Error(String),
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/mod.rs
@@ -1,0 +1,489 @@
+mod messages;
+pub(super) mod providers;
+mod watchers;
+
+use std::sync::Arc;
+
+use gtk::prelude::*;
+use relm4::{gtk, prelude::*};
+use wayle_config::ConfigService;
+use wayle_network::NetworkService;
+use wayle_widgets::prelude::*;
+
+pub(crate) use self::messages::{
+    VpnProviderConfig, VpnTunnelsInit, VpnTunnelsInput, VpnTunnelsOutput,
+};
+use self::messages::{TunnelState, VpnTunnelsCmd};
+
+pub(crate) struct VpnTunnels {
+    network: Arc<NetworkService>,
+    config: Arc<ConfigService>,
+    provider: VpnProviderConfig,
+    tunnels: Vec<TunnelState>,
+    tunnels_box: gtk::Box,
+    service_available: bool,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for VpnTunnels {
+    type Init = VpnTunnelsInit;
+    type Input = VpnTunnelsInput;
+    type Output = VpnTunnelsOutput;
+    type CommandOutput = VpnTunnelsCmd;
+
+    view! {
+        #[root]
+        gtk::Box {
+            set_orientation: gtk::Orientation::Vertical,
+            #[watch]
+            set_visible: model.service_available,
+
+            #[name = "section_label"]
+            gtk::Label {
+                add_css_class: "section-label",
+                set_halign: gtk::Align::Start,
+                #[watch]
+                set_visible: !model.tunnels.is_empty(),
+            },
+
+            #[template]
+            Card {
+                add_css_class: "network-connections-group",
+                set_orientation: gtk::Orientation::Vertical,
+                #[watch]
+                set_visible: !model.tunnels.is_empty(),
+
+                #[name = "tunnels_box"]
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                },
+            },
+
+            #[name = "import_row"]
+            gtk::Box {
+                add_css_class: "network-vpn-import-row",
+                set_halign: gtk::Align::Start,
+                set_margin_top: 4,
+
+                #[template]
+                GhostButton {
+                    add_css_class: "network-vpn-import",
+                    #[template_child]
+                    label {
+                        set_label: &crate::i18n::t!("dropdown-network-wireguard-import"),
+                    },
+                    connect_clicked => VpnTunnelsInput::ImportConfig,
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let service_available = providers::wireguard_available(&init.network);
+        let mut tunnels = providers::wireguard_tunnels(&init.network);
+        apply_aliases(&mut tunnels, &init.config);
+
+        watchers::spawn(&sender, &init.network, &init.config);
+
+        let mut model = Self {
+            network: init.network.clone(),
+            config: init.config,
+            provider: init.provider,
+            tunnels,
+            tunnels_box: gtk::Box::default(),
+            service_available,
+        };
+
+        let widgets = view_output!();
+
+        // Set provider-specific section label
+        widgets.section_label.set_label(&model.provider.section_label);
+
+        // Store a reference to the tunnels container for reliable rebuilds
+        model.tunnels_box = widgets.tunnels_box.clone();
+
+        rebuild_tunnel_cards(
+            &model.tunnels,
+            &model.provider,
+            &model.tunnels_box,
+            &sender,
+        );
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(
+        &mut self,
+        msg: Self::Input,
+        sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            VpnTunnelsInput::ToggleTunnel(index, desired_active) => {
+                self.toggle_tunnel(index, desired_active, &sender);
+            }
+            VpnTunnelsInput::RenameTunnel(index, new_name) => {
+                self.rename_tunnel(index, &new_name);
+                rebuild_tunnel_cards(
+                    &self.tunnels,
+                    &self.provider,
+                    &self.tunnels_box,
+                    &sender,
+                );
+            }
+            VpnTunnelsInput::ImportConfig => {
+                self.open_import_dialog(&sender);
+            }
+            VpnTunnelsInput::FileSelected(name, content) => {
+                self.import_file(&name, &content, &sender);
+            }
+        }
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: VpnTunnelsCmd,
+        sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            VpnTunnelsCmd::TunnelsChanged(mut tunnels) => {
+                apply_aliases(&mut tunnels, &self.config);
+                self.tunnels = tunnels;
+
+                rebuild_tunnel_cards(
+                    &self.tunnels,
+                    &self.provider,
+                    &self.tunnels_box,
+                    &sender,
+                );
+            }
+            VpnTunnelsCmd::ServiceChanged => {
+                self.service_available =
+                    providers::wireguard_available(&self.network);
+                watchers::spawn_tunnel_watchers(&sender, &self.network);
+            }
+            VpnTunnelsCmd::ToggleResult(index, result) => {
+                if let Err(err) = result {
+                    let name = self
+                        .tunnels
+                        .get(index)
+                        .map(|t| t.name.clone())
+                        .unwrap_or_default();
+                    let _ = sender
+                        .output(VpnTunnelsOutput::Error(format!("{name}: {err}")));
+                }
+            }
+            VpnTunnelsCmd::ImportResult(result) => match result {
+                Ok(name) => {
+                    let _ = sender.output(VpnTunnelsOutput::Activated(name));
+                }
+                Err(err) => {
+                    let _ = sender.output(VpnTunnelsOutput::Error(err));
+                }
+            },
+        }
+    }
+}
+
+impl VpnTunnels {
+    fn toggle_tunnel(
+        &self,
+        index: usize,
+        desired_active: bool,
+        sender: &ComponentSender<Self>,
+    ) {
+        let Some(tunnel) = self.tunnels.get(index) else {
+            return;
+        };
+
+        let network = self.network.clone();
+        let connection_path = tunnel.connection_path.clone();
+        let uuid = tunnel.uuid.clone();
+
+        // Currently dispatches to WireGuard. When adding new providers,
+        // this should dispatch based on self.provider or connection type.
+        sender.command(move |out, _shutdown| async move {
+            let Some(wg) = network.wireguard.get() else {
+                let _ = out.send(VpnTunnelsCmd::ToggleResult(
+                    index,
+                    Err(String::from("VPN service not available")),
+                ));
+                return;
+            };
+
+            // Use the switch's desired state rather than any cached active
+            // flag, which may be stale if NM monitoring hasn't refreshed yet.
+            let result = if desired_active {
+                wg.activate(&connection_path).await.map(|_| ())
+            } else {
+                // Query NM directly for the active connection path to avoid
+                // stale cached state on the tunnel objects.
+                wg.deactivate_by_uuid(&uuid).await
+            };
+
+            let _ = out.send(VpnTunnelsCmd::ToggleResult(
+                index,
+                result.map_err(|e| e.to_string()),
+            ));
+        });
+    }
+
+    fn rename_tunnel(&mut self, index: usize, new_name: &str) {
+        let Some(tunnel) = self.tunnels.get_mut(index) else {
+            return;
+        };
+
+        let mut aliases = self
+            .config
+            .config()
+            .modules
+            .network
+            .vpn_aliases
+            .get();
+
+        let trimmed = new_name.trim().to_owned();
+        if trimmed.is_empty() {
+            aliases.remove(&tunnel.uuid);
+            // Re-derive original name from provider data
+            let original = providers::wireguard_tunnels(&self.network);
+            if let Some(orig) = original.iter().find(|t| t.uuid == tunnel.uuid) {
+                tunnel.name = orig.name.clone();
+            }
+        } else {
+            aliases.insert(tunnel.uuid.clone(), trimmed.clone());
+            tunnel.name = trimmed;
+        }
+
+        self.config
+            .config()
+            .modules
+            .network
+            .vpn_aliases
+            .set(aliases);
+    }
+
+    fn open_import_dialog(&self, sender: &ComponentSender<Self>) {
+        let input_sender = sender.input_sender().clone();
+        let import_filter = self.provider.import_filter.to_owned();
+        let import_filter_label = self.provider.import_filter_label.to_owned();
+
+        relm4::spawn_local(async move {
+            let dialog = gtk::FileDialog::builder()
+                .title("Import VPN Configuration")
+                .build();
+
+            let filter = gtk::FileFilter::new();
+            filter.add_pattern(&import_filter);
+            filter.set_name(Some(&import_filter_label));
+
+            let filters = gtk::gio::ListStore::new::<gtk::FileFilter>();
+            filters.append(&filter);
+            dialog.set_filters(Some(&filters));
+
+            let window: Option<&gtk::Window> = None;
+            if let Ok(file) = dialog.open_future(window).await
+                && let Some(path) = file.path()
+            {
+                let name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("vpn")
+                    .to_owned();
+
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    input_sender
+                        .emit(VpnTunnelsInput::FileSelected(name, content));
+                }
+            }
+        });
+    }
+
+    fn import_file(
+        &self,
+        name: &str,
+        content: &str,
+        sender: &ComponentSender<Self>,
+    ) {
+        let network = self.network.clone();
+        let name = name.to_owned();
+        let content = content.to_owned();
+
+        // Currently dispatches to WireGuard. When adding new providers,
+        // this should dispatch based on self.provider or connection type.
+        sender.command(move |out, _shutdown| async move {
+            let Some(wg) = network.wireguard.get() else {
+                let _ = out.send(VpnTunnelsCmd::ImportResult(Err(
+                    String::from("VPN service not available"),
+                )));
+                return;
+            };
+
+            let result = wg
+                .import(&name, &content)
+                .await
+                .map(|_| name.clone())
+                .map_err(|e| e.to_string());
+
+            let _ = out.send(VpnTunnelsCmd::ImportResult(result));
+        });
+    }
+}
+
+/// Applies user-configured display name aliases to tunnel states.
+fn apply_aliases(tunnels: &mut [TunnelState], config: &ConfigService) {
+    let aliases = config.config().modules.network.vpn_aliases.get();
+    for tunnel in tunnels.iter_mut() {
+        if let Some(alias) = aliases.get(&tunnel.uuid) {
+            tunnel.name = alias.clone();
+        }
+    }
+}
+
+fn rebuild_tunnel_cards(
+    tunnels: &[TunnelState],
+    provider: &VpnProviderConfig,
+    container: &gtk::Box,
+    sender: &ComponentSender<VpnTunnels>,
+) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
+    }
+
+    for (index, tunnel) in tunnels.iter().enumerate() {
+        let card = build_tunnel_card(index, tunnel, provider, sender);
+        container.append(&card);
+    }
+}
+
+fn build_tunnel_card(
+    index: usize,
+    tunnel: &TunnelState,
+    provider: &VpnProviderConfig,
+    sender: &ComponentSender<VpnTunnels>,
+) -> gtk::Box {
+    let card = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    card.add_css_class("network-connection-card");
+
+    // Icon
+    let icon_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    icon_box.add_css_class("network-connection-icon");
+    icon_box.add_css_class("vpn");
+    icon_box.set_hexpand(false);
+
+    let icon = gtk::Image::from_icon_name(provider.icon);
+    icon.set_halign(gtk::Align::Center);
+    icon.set_valign(gtk::Align::Center);
+    icon_box.append(&icon);
+    card.append(&icon_box);
+
+    // Info with inline-editable name
+    let info_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    info_box.add_css_class("network-connection-info");
+    info_box.set_hexpand(true);
+
+    let name_stack = gtk::Stack::new();
+    name_stack.set_transition_type(gtk::StackTransitionType::None);
+
+    let name_label = gtk::Label::new(Some(&tunnel.name));
+    name_label.add_css_class("network-connection-name");
+    name_label.set_halign(gtk::Align::Start);
+    name_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+
+    let name_entry = gtk::Entry::new();
+    name_entry.set_text(&tunnel.name);
+    name_entry.add_css_class("network-connection-name-edit");
+    name_entry.set_halign(gtk::Align::Fill);
+    name_entry.set_hexpand(true);
+
+    name_stack.add_named(&name_label, Some("label"));
+    name_stack.add_named(&name_entry, Some("entry"));
+    name_stack.set_visible_child_name("label");
+
+    // Double-click to enter edit mode
+    let gesture = gtk::GestureClick::new();
+    gesture.set_button(1);
+    let stack_clone = name_stack.clone();
+    let entry_clone = name_entry.clone();
+    let label_clone = name_label.clone();
+    gesture.connect_pressed(move |gesture, n_press, _, _| {
+        if n_press == 2 {
+            entry_clone.set_text(&label_clone.text());
+            stack_clone.set_visible_child_name("entry");
+            entry_clone.grab_focus();
+            gesture.set_state(gtk::EventSequenceState::Claimed);
+        }
+    });
+    name_label.add_controller(gesture);
+
+    // Enter commits the rename
+    let stack_commit = name_stack.clone();
+    let rename_sender = sender.input_sender().clone();
+    name_entry.connect_activate(move |entry| {
+        let new_name = entry.text().to_string();
+        stack_commit.set_visible_child_name("label");
+        rename_sender.emit(VpnTunnelsInput::RenameTunnel(index, new_name));
+    });
+
+    // Escape cancels editing
+    let key_controller = gtk::EventControllerKey::new();
+    let stack_cancel = name_stack.clone();
+    key_controller.connect_key_pressed(move |_, key, _, _| {
+        if key == gtk::gdk::Key::Escape {
+            stack_cancel.set_visible_child_name("label");
+            return gtk::glib::Propagation::Stop;
+        }
+        gtk::glib::Propagation::Proceed
+    });
+    name_entry.add_controller(key_controller);
+
+    info_box.append(&name_stack);
+
+    // Detail line (IP/interface when active)
+    if tunnel.active {
+        let detail_parts: Vec<String> = [
+            tunnel.ip4_address.clone(),
+            tunnel.interface_name.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        if !detail_parts.is_empty() {
+            let detail_label =
+                gtk::Label::new(Some(&detail_parts.join(" - ")));
+            detail_label.add_css_class("network-connection-detail");
+            detail_label.set_halign(gtk::Align::Start);
+            info_box.append(&detail_label);
+        }
+    }
+
+    card.append(&info_box);
+
+    // Toggle switch — disabled for externally managed tunnels (e.g. wg-quick)
+    // to prevent NM from corrupting their config files.
+    let switch = gtk::Switch::new();
+    switch.set_active(tunnel.active);
+    switch.set_valign(gtk::Align::Center);
+    switch.add_css_class("network-vpn-toggle");
+    switch.set_sensitive(!tunnel.externally_managed);
+
+    if tunnel.externally_managed {
+        switch.set_tooltip_text(Some("Managed externally (e.g. wg-quick)"));
+    }
+
+    let toggle_sender = sender.input_sender().clone();
+    switch.connect_state_set(move |s, active| {
+        s.set_state(active);
+        toggle_sender.emit(VpnTunnelsInput::ToggleTunnel(index, active));
+        gtk::glib::Propagation::Stop
+    });
+
+    card.append(&switch);
+
+    card
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/providers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/providers.rs
@@ -1,0 +1,66 @@
+//! VPN provider adapters that bridge generic tunnel UI with specific backends.
+
+use std::sync::Arc;
+
+use wayle_network::{NetworkService, types::flags::NMConnectionSettingsFlags};
+
+use super::messages::{TunnelState, VpnProviderConfig};
+use crate::i18n::t;
+
+/// Creates a WireGuard provider configuration.
+pub(in crate::shell::bar::dropdowns::network) fn wireguard_config() -> VpnProviderConfig {
+    VpnProviderConfig {
+        section_label: t!("dropdown-network-wireguard-tunnels"),
+        fallback_name: "WireGuard",
+        icon: "md-vpn_lock_2-symbolic",
+        import_filter: "*.conf",
+        import_filter_label: "WireGuard Config (*.conf)",
+    }
+}
+
+/// Reads the current WireGuard tunnel list as generic `TunnelState` snapshots.
+pub(super) fn wireguard_tunnels(network: &Arc<NetworkService>) -> Vec<TunnelState> {
+    let config = wireguard_config();
+    let Some(wg) = network.wireguard.get() else {
+        return vec![];
+    };
+
+    let mut tunnels: Vec<TunnelState> = wg
+        .tunnels
+        .get()
+        .iter()
+        .map(|t| {
+            let id = t.profile.id.get();
+            let interface_name = t.interface_name.get();
+            let name = if id.is_empty() {
+                interface_name
+                    .clone()
+                    .unwrap_or_else(|| String::from(config.fallback_name))
+            } else {
+                id
+            };
+
+            TunnelState {
+                uuid: t.profile.uuid.get(),
+                name,
+                active: t.active.get(),
+                externally_managed: t
+                    .profile
+                    .flags
+                    .get()
+                    .contains(NMConnectionSettingsFlags::EXTERNAL),
+                ip4_address: t.ip4_address.get(),
+                interface_name,
+                connection_path: t.profile.object_path.clone(),
+            }
+        })
+        .collect();
+
+    tunnels.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    tunnels
+}
+
+/// Checks whether the WireGuard backend service is available.
+pub(super) fn wireguard_available(network: &Arc<NetworkService>) -> bool {
+    network.wireguard.get().is_some()
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/vpn_tunnels/watchers.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use relm4::ComponentSender;
+use wayle_widgets::watch;
+use wayle_config::ConfigService;
+use wayle_network::NetworkService;
+
+use super::{VpnTunnels, messages::VpnTunnelsCmd, providers};
+
+pub(super) fn spawn(
+    sender: &ComponentSender<VpnTunnels>,
+    network: &Arc<NetworkService>,
+    config: &Arc<ConfigService>,
+) {
+    // Watch for WireGuard service availability changes (hot-plug).
+    // When adding new VPN providers, add their service watchers here.
+    let wg_service = network.wireguard.clone();
+    watch!(sender, [wg_service.watch()], |out| {
+        let _ = out.send(VpnTunnelsCmd::ServiceChanged);
+    });
+
+    // Watch for alias changes (e.g. from another panel instance).
+    let aliases_prop = config.config().modules.network.vpn_aliases.clone();
+    let network_alias = network.clone();
+    watch!(sender, [aliases_prop.watch()], |out| {
+        let _ = out.send(VpnTunnelsCmd::TunnelsChanged(
+            providers::wireguard_tunnels(&network_alias),
+        ));
+    });
+
+    spawn_tunnel_watchers(sender, network);
+}
+
+pub(super) fn spawn_tunnel_watchers(
+    sender: &ComponentSender<VpnTunnels>,
+    network: &Arc<NetworkService>,
+) {
+    // Watch WireGuard tunnel changes.
+    // When adding new VPN providers, add their tunnel watchers here.
+    let Some(wg) = network.wireguard.get() else {
+        return;
+    };
+
+    let network = network.clone();
+    let tunnels_prop = wg.tunnels.clone();
+    watch!(sender, [tunnels_prop.watch()], |out| {
+        let _ = out.send(VpnTunnelsCmd::TunnelsChanged(
+            providers::wireguard_tunnels(&network),
+        ));
+    });
+}

--- a/crates/wayle-styling/scss/modules/network_dropdown/_active_connection.scss
+++ b/crates/wayle-styling/scss/modules/network_dropdown/_active_connection.scss
@@ -38,6 +38,16 @@
             color: var(--accent);
         }
     }
+
+    &.vpn {
+        background: var(--accent-subtle);
+
+        image {
+            margin: calc(var(--space-sm) + var(--space-xs));
+            -gtk-icon-size: var(--icon-md);
+            color: var(--accent);
+        }
+    }
 }
 
 .network-connection-name {
@@ -97,4 +107,14 @@
 
 button.network-action-forget:hover {
     color: var(--status-error);
+}
+
+.network-connection-name-edit {
+    border: none;
+    background: transparent;
+    padding: 0;
+    min-height: 0;
+    font-size: var(--text-md);
+    font-weight: var(--weight-bold);
+    color: var(--fg-default);
 }


### PR DESCRIPTION
feat(shell): add VPN tunnel UI for WireGuard connections

  Add VPN tunnels dropdown section with toggle switches, connection status,
  and configurable display aliases. Includes VPN icon styling, i18n strings,
  and a provider abstraction to support additional VPN types in the future.

This requires PR# 8 in the services repo to precede it and replaces the PR from before the services split.