### PR TITLE
feat: add discord icon for Equibop

### DIFF
--- a/crates/wayle-config/src/schemas/modules/window_title/icons.rs
+++ b/crates/wayle-config/src/schemas/modules/window_title/icons.rs
@@ -40,6 +40,7 @@ pub const BUILTIN_MAPPINGS: &[(&str, &str)] = &[
     ("*discord*", "si-discord-symbolic"),
     ("*legcord*", "si-discord-symbolic"),
     ("*vesktop*", "si-discord-symbolic"),
+    ("equibop", "si-discord-symbolic"),
     ("*webcord*", "si-discord-symbolic"),
     ("*element*", "si-element-symbolic"),
     ("*signal*", "si-signal-symbolic"),

--- a/crates/wayle-shell/src/shell/bar/icons.rs
+++ b/crates/wayle-shell/src/shell/bar/icons.rs
@@ -123,6 +123,7 @@ pub(crate) const DEFAULT_APP_ICON_MAP: &[(&str, &str)] = &[
     ("*telegram*", "si-telegram-symbolic"),
     ("*thunderbird*", "si-thunderbird-symbolic"),
     ("*vesktop*", "si-discord-symbolic"),
+    ("equibop", "si-discord-symbolic"),
     ("*webcord*", "si-discord-symbolic"),
     ("*whatsapp*", "si-whatsapp-symbolic"),
     ("*wire*", "si-wire-symbolic"),


### PR DESCRIPTION
[Equibop](https://equibop.org/) is a Vesktop fork with more plugins