### PR TITLE
feat: add built-in GPU bar module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2370,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
+dependencies = [
+ "bitflags 2.10.0",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -3519,6 +3583,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
@@ -4844,6 +4914,7 @@ dependencies = [
  "indicatif",
  "minijinja",
  "notify",
+ "nvml-wrapper",
  "relm4",
  "rust-embed",
  "serde",
@@ -5483,6 +5554,18 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/wayle-config/src/schemas/bar/types/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/types/mod.rs
@@ -205,6 +205,8 @@ pub enum BarModule {
     Clock,
     /// CPU usage indicator.
     Cpu,
+    /// GPU usage, temperature, and VRAM.
+    Gpu,
     /// Quick access dashboard button.
     Dashboard,
     /// Compositor keybind mode indicator (submaps in Hyprland, modes in Sway/River).
@@ -286,6 +288,7 @@ impl BarModule {
             Self::Cava => "cava",
             Self::Clock => "clock",
             Self::Cpu => "cpu",
+            Self::Gpu => "gpu",
             Self::Dashboard => "dashboard",
             Self::KeybindMode => "keybind-mode",
             Self::HyprlandWorkspaces => "hyprland-workspaces",
@@ -318,6 +321,7 @@ impl BarModule {
             "cava" => Self::Cava,
             "clock" => Self::Clock,
             "cpu" => Self::Cpu,
+            "gpu" => Self::Gpu,
             "dashboard" => Self::Dashboard,
             "keybind-mode" => Self::KeybindMode,
             "hyprland-workspaces" => Self::HyprlandWorkspaces,
@@ -402,6 +406,7 @@ const BUILTIN_MODULES: &[&str] = &[
     "clock",
     "cpu",
     "dashboard",
+    "gpu",
     "hyprland-workspaces",
     "hyprsunset",
     "idle-inhibit",

--- a/crates/wayle-config/src/schemas/modules/gpu/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/gpu/mod.rs
@@ -1,0 +1,169 @@
+use schemars::schema_for;
+use wayle_derive::wayle_config;
+
+use crate::{
+    ClickAction, ConfigProperty,
+    docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
+    schemas::styling::{ColorValue, CssToken, ThresholdEntry},
+};
+
+/// GPU usage, temperature, and VRAM.
+///
+/// Supports NVIDIA (via NVML) and AMD (via sysfs/hwmon).
+/// The module auto-detects the GPU vendor on startup.
+#[wayle_config(bar_button, i18n_prefix = "settings-modules-gpu")]
+pub struct GpuConfig {
+    /// Polling interval in milliseconds.
+    #[serde(rename = "poll-interval-ms")]
+    #[default(5000)]
+    pub poll_interval_ms: ConfigProperty<u64>,
+
+    /// GPU vendor override.
+    ///
+    /// Use `"auto"` for automatic detection, or force a specific vendor:
+    /// `"nvidia"`, `"amd"`.
+    #[serde(rename = "vendor")]
+    #[default(String::from("auto"))]
+    pub vendor: ConfigProperty<String>,
+
+    /// GPU device index.
+    ///
+    /// For AMD, selects which `/sys/class/drm/card<N>` to read from.
+    /// For NVIDIA, selects the NVML device index.
+    /// Set to `0` for the first GPU, `1` for the second, etc.
+    #[serde(rename = "card-index")]
+    #[default(0)]
+    pub card_index: ConfigProperty<u32>,
+
+    /// Format string for the label.
+    ///
+    /// ## Placeholders
+    ///
+    /// - `{{ percent }}` - GPU usage (0-100)
+    /// - `{{ temp_c }}` - Temperature in Celsius
+    /// - `{{ temp_f }}` - Temperature in Fahrenheit
+    /// - `{{ vram_used_mb }}` - VRAM used in MB
+    /// - `{{ vram_total_mb }}` - VRAM total in MB
+    /// - `{{ vram_percent }}` - VRAM usage percentage
+    /// - `{{ name }}` - GPU model name
+    ///
+    /// ## Examples
+    ///
+    /// - `"{{ percent }}%"` - "45%"
+    /// - `"{{ percent }}% {{ temp_c }}°C"` - "45% 62°C"
+    /// - `"{{ vram_used_mb }}/{{ vram_total_mb }}MB"` - "2048/8192MB"
+    #[serde(rename = "format")]
+    #[default(String::from("{{ percent }}%"))]
+    pub format: ConfigProperty<String>,
+
+    /// Icon name.
+    #[serde(rename = "icon-name")]
+    #[default(String::from("ld-gpu-symbolic"))]
+    pub icon_name: ConfigProperty<String>,
+
+    /// Display border around button.
+    #[serde(rename = "border-show")]
+    #[default(false)]
+    pub border_show: ConfigProperty<bool>,
+
+    /// Border color token.
+    #[serde(rename = "border-color")]
+    #[default(ColorValue::Token(CssToken::Green))]
+    pub border_color: ConfigProperty<ColorValue>,
+
+    /// Display module icon.
+    #[serde(rename = "icon-show")]
+    #[default(true)]
+    pub icon_show: ConfigProperty<bool>,
+
+    /// Icon foreground color.
+    #[serde(rename = "icon-color")]
+    #[default(ColorValue::Auto)]
+    pub icon_color: ConfigProperty<ColorValue>,
+
+    /// Icon container background color token.
+    #[serde(rename = "icon-bg-color")]
+    #[default(ColorValue::Token(CssToken::Green))]
+    pub icon_bg_color: ConfigProperty<ColorValue>,
+
+    /// Display label.
+    #[serde(rename = "label-show")]
+    #[default(true)]
+    pub label_show: ConfigProperty<bool>,
+
+    /// Label text color token.
+    #[serde(rename = "label-color")]
+    #[default(ColorValue::Token(CssToken::Green))]
+    pub label_color: ConfigProperty<ColorValue>,
+
+    /// Max label characters before truncation. Set to 0 to disable.
+    #[serde(rename = "label-max-length")]
+    #[default(0)]
+    pub label_max_length: ConfigProperty<u32>,
+
+    /// Button background color token.
+    #[serde(rename = "button-bg-color")]
+    #[default(ColorValue::Token(CssToken::BgSurfaceElevated))]
+    pub button_bg_color: ConfigProperty<ColorValue>,
+
+    /// Action on left click.
+    #[serde(rename = "left-click")]
+    #[default(ClickAction::None)]
+    pub left_click: ConfigProperty<ClickAction>,
+
+    /// Action on right click.
+    #[serde(rename = "right-click")]
+    #[default(ClickAction::None)]
+    pub right_click: ConfigProperty<ClickAction>,
+
+    /// Action on middle click.
+    #[serde(rename = "middle-click")]
+    #[default(ClickAction::None)]
+    pub middle_click: ConfigProperty<ClickAction>,
+
+    /// Action on scroll up.
+    #[serde(rename = "scroll-up")]
+    #[default(ClickAction::None)]
+    pub scroll_up: ConfigProperty<ClickAction>,
+
+    /// Action on scroll down.
+    #[serde(rename = "scroll-down")]
+    #[default(ClickAction::None)]
+    pub scroll_down: ConfigProperty<ClickAction>,
+
+    /// Dynamic color thresholds based on GPU usage percentage.
+    ///
+    /// ## Example
+    ///
+    /// ```toml
+    /// [[modules.gpu.thresholds]]
+    /// above = 70
+    /// icon-color = "status-warning"
+    /// label-color = "status-warning"
+    ///
+    /// [[modules.gpu.thresholds]]
+    /// above = 90
+    /// icon-color = "status-error"
+    /// label-color = "status-error"
+    /// ```
+    #[serde(rename = "thresholds")]
+    #[default(Vec::new())]
+    pub thresholds: ConfigProperty<Vec<ThresholdEntry>>,
+}
+
+impl ModuleInfoProvider for GpuConfig {
+    fn module_info() -> ModuleInfo {
+        ModuleInfo {
+            name: String::from("gpu"),
+            schema: || schema_for!(GpuConfig),
+            layout_id: Some(String::from("gpu")),
+            array_entry: false,
+        }
+    }
+
+    fn groups() -> Vec<ConfigGroup> {
+        GroupDefaults::bar_button()
+    }
+}
+
+crate::register_module!(GpuConfig);

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -7,6 +7,7 @@ mod clock;
 mod cpu;
 mod custom;
 mod dashboard;
+mod gpu;
 mod hyprland_workspaces;
 mod hyprsunset;
 mod idle_inhibit;
@@ -38,6 +39,7 @@ pub use clock::ClockConfig;
 pub use cpu::CpuConfig;
 pub use custom::{CustomModuleDefinition, ExecutionMode, RestartDelay, RestartPolicy};
 pub use dashboard::DashboardConfig;
+pub use gpu::GpuConfig;
 pub use hyprland_workspaces::{
     ActiveIndicator, DisplayMode, HyprlandWorkspacesConfig, Numbering, UrgentMode, WorkspaceStyle,
 };
@@ -80,6 +82,8 @@ pub struct ModulesConfig {
     pub clock: ClockConfig,
     /// CPU usage module.
     pub cpu: CpuConfig,
+    /// GPU usage module.
+    pub gpu: GpuConfig,
     /// Dashboard module.
     pub dashboard: DashboardConfig,
     /// Hyprland workspace switcher module.

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -24,6 +24,7 @@ mod ram;
 mod separator;
 mod storage;
 mod systray;
+mod updates;
 mod volume;
 mod weather;
 mod window_title;
@@ -61,6 +62,7 @@ pub use separator::SeparatorConfig;
 pub use storage::StorageConfig;
 pub use systray::{SystrayConfig, TrayItemOverride};
 pub use types::TimeFormat;
+pub use updates::UpdatesConfig;
 pub use volume::{AppIconSource, VolumeConfig};
 use wayle_derive::wayle_config;
 pub use weather::{TemperatureUnit, WeatherConfig, WeatherProvider};
@@ -120,6 +122,8 @@ pub struct ModulesConfig {
     pub separator: SeparatorConfig,
     /// System tray module.
     pub systray: SystrayConfig,
+    /// System updates module.
+    pub updates: UpdatesConfig,
     /// Volume control module.
     pub volume: VolumeConfig,
     /// Weather display module.

--- a/crates/wayle-config/src/schemas/modules/updates/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/updates/mod.rs
@@ -7,59 +7,64 @@ use crate::{
     schemas::styling::{ColorValue, CssToken, ThresholdEntry},
 };
 
-/// GPU usage, temperature, and VRAM.
+/// System package updates indicator.
 ///
-/// Supports NVIDIA (via NVML) and AMD (via sysfs/hwmon).
-/// The module auto-detects the GPU vendor on startup.
-#[wayle_config(bar_button, i18n_prefix = "settings-modules-gpu")]
-pub struct GpuConfig {
+/// Checks for available updates from official repositories (pacman/checkupdates)
+/// and AUR (paru/yay). Displays counts in the bar and provides a dropdown
+/// with refresh and update actions.
+#[wayle_config(bar_button, i18n_prefix = "settings-modules-updates")]
+pub struct UpdatesConfig {
     /// Polling interval in milliseconds.
     #[serde(rename = "poll-interval-ms")]
-    #[default(5000)]
+    #[default(3600000)]
     pub poll_interval_ms: ConfigProperty<u64>,
-
-    /// GPU vendor override.
-    ///
-    /// Use `"auto"` for automatic detection, or force a specific vendor:
-    /// `"nvidia"`, `"amd"`.
-    #[serde(rename = "vendor")]
-    #[default(String::from("auto"))]
-    pub vendor: ConfigProperty<String>,
-
-    /// GPU device index.
-    ///
-    /// For AMD, selects which `/sys/class/drm/card<N>` to read from.
-    /// For NVIDIA, selects the NVML device index.
-    /// Set to `0` for the first GPU, `1` for the second, etc.
-    #[serde(rename = "card-index")]
-    #[default(0)]
-    pub card_index: ConfigProperty<u32>,
 
     /// Format string for the label.
     ///
     /// ## Placeholders
     ///
-    /// - `{{ percent }}` - GPU usage (0-100)
-    /// - `{{ temp_c }}` - Temperature in Celsius
-    /// - `{{ temp_f }}` - Temperature in Fahrenheit
-    /// - `{{ vram_used_mb }}` - VRAM used in MB
-    /// - `{{ vram_total_mb }}` - VRAM total in MB
-    /// - `{{ vram_percent }}` - VRAM usage percentage
-    /// - `{{ name }}` - GPU model name
+    /// - `{{ pacman }}` - Official repository updates count
+    /// - `{{ aur }}` - AUR updates count
+    /// - `{{ flatpak }}` - Flatpak updates count
+    /// - `{{ total }}` - Total updates (pacman + aur + flatpak)
     ///
     /// ## Examples
     ///
-    /// - `"{{ percent }}%"` - "45%"
-    /// - `"{{ percent }}% {{ temp_c }}°C"` - "45% 62°C"
-    /// - `"{{ vram_used_mb }}/{{ vram_total_mb }}MB"` - "2048/8192MB"
+    /// - `"{{ total }}"` - "169"
+    /// - `"pac:{{ pacman }} aur:{{ aur }}"` - "pac:145 aur:24"
     #[serde(rename = "format")]
-    #[default(String::from("{{ percent }}%"))]
+    #[default(String::from("{{ total }}"))]
     pub format: ConfigProperty<String>,
 
     /// Icon name.
     #[serde(rename = "icon-name")]
-    #[default(String::from("ld-gpu-symbolic"))]
+    #[default(String::from("md-package_2-symbolic"))]
     pub icon_name: ConfigProperty<String>,
+
+    /// Hide module when no updates are available.
+    #[serde(rename = "hide-if-zero")]
+    #[default(false)]
+    pub hide_if_zero: ConfigProperty<bool>,
+
+    /// Command to check official repository updates.
+    #[serde(rename = "check-official-command")]
+    #[default(String::from("checkupdates 2>/dev/null | wc -l"))]
+    pub check_official_command: ConfigProperty<String>,
+
+    /// Command to check AUR updates.
+    #[serde(rename = "check-aur-command")]
+    #[default(String::from("paru -Qua 2>/dev/null | wc -l"))]
+    pub check_aur_command: ConfigProperty<String>,
+
+    /// Command to check Flatpak updates.
+    #[serde(rename = "check-flatpak-command")]
+    #[default(String::from("flatpak remote-ls --updates 2>/dev/null | wc -l"))]
+    pub check_flatpak_command: ConfigProperty<String>,
+
+    /// Command to run system update (launched in terminal).
+    #[serde(rename = "update-command")]
+    #[default(String::from("paru -Syu"))]
+    pub update_command: ConfigProperty<String>,
 
     /// Display border around button.
     #[serde(rename = "border-show")]
@@ -68,7 +73,7 @@ pub struct GpuConfig {
 
     /// Border color token.
     #[serde(rename = "border-color")]
-    #[default(ColorValue::Token(CssToken::Green))]
+    #[default(ColorValue::Token(CssToken::Blue))]
     pub border_color: ConfigProperty<ColorValue>,
 
     /// Display module icon.
@@ -83,7 +88,7 @@ pub struct GpuConfig {
 
     /// Icon container background color token.
     #[serde(rename = "icon-bg-color")]
-    #[default(ColorValue::Token(CssToken::Green))]
+    #[default(ColorValue::Token(CssToken::Blue))]
     pub icon_bg_color: ConfigProperty<ColorValue>,
 
     /// Display label.
@@ -93,7 +98,7 @@ pub struct GpuConfig {
 
     /// Label text color token.
     #[serde(rename = "label-color")]
-    #[default(ColorValue::Token(CssToken::Green))]
+    #[default(ColorValue::Token(CssToken::Blue))]
     pub label_color: ConfigProperty<ColorValue>,
 
     /// Max label characters before truncation. Set to 0 to disable.
@@ -108,7 +113,7 @@ pub struct GpuConfig {
 
     /// Action on left click.
     #[serde(rename = "left-click")]
-    #[default(ClickAction::Dropdown(String::from("sysinfo")))]
+    #[default(ClickAction::Dropdown(String::from("updates")))]
     pub left_click: ConfigProperty<ClickAction>,
 
     /// Action on right click.
@@ -131,32 +136,18 @@ pub struct GpuConfig {
     #[default(ClickAction::None)]
     pub scroll_down: ConfigProperty<ClickAction>,
 
-    /// Dynamic color thresholds based on GPU usage percentage.
-    ///
-    /// ## Example
-    ///
-    /// ```toml
-    /// [[modules.gpu.thresholds]]
-    /// above = 70
-    /// icon-color = "status-warning"
-    /// label-color = "status-warning"
-    ///
-    /// [[modules.gpu.thresholds]]
-    /// above = 90
-    /// icon-color = "status-error"
-    /// label-color = "status-error"
-    /// ```
+    /// Dynamic color thresholds based on total update count.
     #[serde(rename = "thresholds")]
     #[default(Vec::new())]
     pub thresholds: ConfigProperty<Vec<ThresholdEntry>>,
 }
 
-impl ModuleInfoProvider for GpuConfig {
+impl ModuleInfoProvider for UpdatesConfig {
     fn module_info() -> ModuleInfo {
         ModuleInfo {
-            name: String::from("gpu"),
-            schema: || schema_for!(GpuConfig),
-            layout_id: Some(String::from("gpu")),
+            name: String::from("updates"),
+            schema: || schema_for!(UpdatesConfig),
+            layout_id: Some(String::from("updates")),
             array_entry: false,
         }
     }
@@ -166,4 +157,4 @@ impl ModuleInfoProvider for GpuConfig {
     }
 }
 
-crate::register_module!(GpuConfig);
+crate::register_module!(UpdatesConfig);

--- a/crates/wayle-config/src/schemas/modules/updates/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/updates/mod.rs
@@ -63,7 +63,7 @@ pub struct UpdatesConfig {
 
     /// Command to run system update (launched in terminal).
     #[serde(rename = "update-command")]
-    #[default(String::from("paru -Syu"))]
+    #[default(String::from("paru -Syu && flatpak update -y"))]
     pub update_command: ConfigProperty<String>,
 
     /// Display border around button.

--- a/crates/wayle-shell/Cargo.toml
+++ b/crates/wayle-shell/Cargo.toml
@@ -34,6 +34,7 @@ tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 evdev = { version = "0.13", features = ["stream-trait"] }
+nvml-wrapper = "0.12.1"
 
 # Service dependencies
 wayle-audio.workspace = true

--- a/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
@@ -7,6 +7,8 @@ mod media;
 mod network;
 mod notification;
 mod registry;
+mod sysinfo;
+mod updates;
 mod weather;
 
 pub(crate) use self::registry::{
@@ -46,5 +48,7 @@ register_dropdowns! {
     "media" => media::Factory,
     "network" => network::Factory,
     "notification" => notification::Factory,
+    "sysinfo" => sysinfo::Factory,
+    "updates" => updates::Factory,
     "weather" => weather::Factory,
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/factory.rs
@@ -1,0 +1,22 @@
+use relm4::prelude::*;
+
+use super::{SysinfoDropdown, messages::SysinfoDropdownInit};
+use crate::shell::{
+    bar::dropdowns::{DropdownFactory, DropdownInstance},
+    services::ShellServices,
+};
+
+pub(crate) struct Factory;
+
+impl DropdownFactory for Factory {
+    fn create(services: &ShellServices) -> Option<DropdownInstance> {
+        let sysinfo = services.sysinfo.clone();
+        let config = services.config.clone();
+
+        let init = SysinfoDropdownInit { sysinfo, config };
+        let controller = SysinfoDropdown::builder().launch(init).detach();
+
+        let popover = controller.widget().clone();
+        Some(DropdownInstance::new(popover, Box::new(controller)))
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/helpers.rs
@@ -1,0 +1,214 @@
+use nvml_wrapper::Nvml;
+use tracing::warn;
+
+// ── NVIDIA ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::shell::bar::dropdowns) struct NvidiaData {
+    pub name: String,
+    pub usage_percent: f32,
+    pub temperature_celsius: Option<f32>,
+    pub vram_used_mb: u64,
+    pub vram_total_mb: u64,
+    pub gpu_clock_mhz: Option<u32>,
+    pub mem_clock_mhz: Option<u32>,
+    pub fan_speed_percent: Option<u32>,
+    pub power_watts: Option<f32>,
+    pub power_limit_watts: Option<f32>,
+}
+
+pub(super) fn init_nvml() -> Option<Nvml> {
+    match Nvml::init() {
+        Ok(nvml) => Some(nvml),
+        Err(e) => {
+            tracing::debug!("NVML init failed: {e}");
+            None
+        }
+    }
+}
+
+pub(super) fn read_nvidia(nvml: &Nvml, device_index: u32) -> NvidiaData {
+    let device = match nvml.device_by_index(device_index) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!("NVML device {device_index}: {e}");
+            return NvidiaData::default();
+        }
+    };
+
+    use nvml_wrapper::enum_wrappers::device::{Clock, TemperatureSensor};
+
+    NvidiaData {
+        name: device.name().unwrap_or_default(),
+        usage_percent: device
+            .utilization_rates()
+            .map(|u| u.gpu as f32)
+            .unwrap_or(0.0),
+        temperature_celsius: device
+            .temperature(TemperatureSensor::Gpu)
+            .ok()
+            .map(|t| t as f32),
+        vram_used_mb: device
+            .memory_info()
+            .map(|m| m.used / (1024 * 1024))
+            .unwrap_or(0),
+        vram_total_mb: device
+            .memory_info()
+            .map(|m| m.total / (1024 * 1024))
+            .unwrap_or(0),
+        gpu_clock_mhz: device.clock_info(Clock::Graphics).ok(),
+        mem_clock_mhz: device.clock_info(Clock::Memory).ok(),
+        fan_speed_percent: device.fan_speed(0).ok(),
+        power_watts: device.power_usage().ok().map(|mw| mw as f32 / 1000.0),
+        power_limit_watts: device
+            .power_management_limit()
+            .ok()
+            .map(|mw| mw as f32 / 1000.0),
+    }
+}
+
+// ── AMD (sysfs) ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::shell::bar::dropdowns) struct AmdData {
+    pub name: String,
+    pub usage_percent: f32,
+    pub temperature_celsius: Option<f32>,
+    pub vram_used_mb: u64,
+    pub vram_total_mb: u64,
+}
+
+pub(super) fn detect_amd_card() -> Option<u32> {
+    for entry in std::fs::read_dir("/sys/class/drm/").ok()?.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("card") || name.contains('-') {
+            continue;
+        }
+        let path = entry.path().join("device/gpu_busy_percent");
+        if path.exists() {
+            return name.strip_prefix("card")?.parse().ok();
+        }
+    }
+    None
+}
+
+pub(super) fn read_amd(card_index: u32) -> AmdData {
+    let card = format!("/sys/class/drm/card{card_index}/device");
+
+    let usage = read_sysfs_u64(&format!("{card}/gpu_busy_percent")).unwrap_or(0);
+    let vram_used = read_sysfs_u64(&format!("{card}/mem_info_vram_used")).unwrap_or(0);
+    let vram_total = read_sysfs_u64(&format!("{card}/mem_info_vram_total")).unwrap_or(0);
+    let temp = find_hwmon_temp(&card);
+
+    let name = read_sysfs_string(&format!("{card}/product_name"))
+        .or_else(|| read_sysfs_string(&format!("{card}/marketing_name")))
+        .unwrap_or_else(|| format!("AMD GPU (card{card_index})"));
+
+    AmdData {
+        name,
+        usage_percent: usage as f32,
+        temperature_celsius: temp,
+        vram_used_mb: vram_used / (1024 * 1024),
+        vram_total_mb: vram_total / (1024 * 1024),
+    }
+}
+
+// ── CPU ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::shell::bar::dropdowns) struct CpuSummary {
+    pub name: String,
+    pub usage_percent: f32,
+    pub temperature_celsius: Option<f32>,
+    pub avg_freq_ghz: f64,
+    pub max_freq_ghz: f64,
+    pub core_count: usize,
+}
+
+/// Read CPU model name from /proc/cpuinfo.
+pub(super) fn read_cpu_name() -> String {
+    std::fs::read_to_string("/proc/cpuinfo")
+        .ok()
+        .and_then(|content| {
+            content
+                .lines()
+                .find(|l| l.starts_with("model name"))
+                .and_then(|l| l.split(':').nth(1))
+                .map(|s| s.trim().to_string())
+        })
+        .unwrap_or_else(|| String::from("CPU"))
+}
+
+// ── Memory ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+pub(in crate::shell::bar::dropdowns) struct MemoryInfo {
+    pub ram_used_gb: f64,
+    pub ram_total_gb: f64,
+    pub ram_percent: f32,
+    pub swap_used_gb: f64,
+    pub swap_total_gb: f64,
+    pub swap_percent: f32,
+}
+
+// ── sysfs helpers ───────────────────────────────────────────────────────
+
+fn find_hwmon_temp(card_device_path: &str) -> Option<f32> {
+    let hwmon_dir = format!("{card_device_path}/hwmon");
+    for entry in std::fs::read_dir(&hwmon_dir).ok()?.flatten() {
+        let temp_path = entry.path().join("temp1_input");
+        if let Some(millideg) = read_sysfs_u64(&temp_path.to_string_lossy()) {
+            return Some(millideg as f32 / 1000.0);
+        }
+    }
+    None
+}
+
+fn read_sysfs_u64(path: &str) -> Option<u64> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+fn read_sysfs_string(path: &str) -> Option<String> {
+    let s = std::fs::read_to_string(path).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────────
+
+pub(super) fn fmt_temp(t: Option<f32>) -> String {
+    t.map(|v| format!("{v:.0}°C")).unwrap_or_else(|| "—".into())
+}
+
+pub(super) fn fmt_vram(used: u64, total: u64) -> String {
+    if total == 0 {
+        return "—".into();
+    }
+    let pct = (used as f64 / total as f64) * 100.0;
+    format!("{used} / {total} MB ({pct:.0}%)")
+}
+
+pub(super) fn fmt_clock(mhz: Option<u32>) -> String {
+    mhz.map(|v| format!("{v} MHz")).unwrap_or_else(|| "—".into())
+}
+
+pub(super) fn fmt_fan(pct: Option<u32>) -> String {
+    match pct {
+        Some(0) => "Off".into(),
+        Some(v) => format!("{v}%"),
+        None => "—".into(),
+    }
+}
+
+pub(super) fn fmt_power(watts: Option<f32>, limit: Option<f32>) -> String {
+    match (watts, limit) {
+        (Some(w), Some(l)) => format!("{w:.0} / {l:.0} W"),
+        (Some(w), None) => format!("{w:.0} W"),
+        (None, Some(l)) => format!("{l:.0} W (limit)"),
+        (None, None) => "—".into(),
+    }
+}
+
+pub(super) fn fmt_gb(gb: f64, total_gb: f64, pct: f32) -> String {
+    format!("{gb:.1} / {total_gb:.1} GB ({pct:.0}%)")
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/messages.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use wayle_config::ConfigService;
+use wayle_sysinfo::SysinfoService;
+
+use super::helpers::{AmdData, CpuSummary, MemoryInfo, NvidiaData};
+
+pub(crate) struct SysinfoDropdownInit {
+    pub sysinfo: Arc<SysinfoService>,
+    pub config: Arc<ConfigService>,
+}
+
+#[derive(Debug)]
+pub(crate) enum SysinfoDropdownInput {}
+
+#[derive(Debug)]
+pub(crate) enum SysinfoDropdownCmd {
+    ScaleChanged(f32),
+    UpdateNvidia(NvidiaData),
+    UpdateAmd(AmdData),
+    UpdateCpu(CpuSummary),
+    UpdateMemory(MemoryInfo),
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/mod.rs
@@ -1,0 +1,434 @@
+mod factory;
+mod helpers;
+mod messages;
+mod watchers;
+
+use std::sync::Arc;
+
+use gtk::prelude::*;
+use relm4::{gtk, prelude::*};
+use wayle_config::ConfigService;
+use wayle_sysinfo::SysinfoService;
+use wayle_widgets::prelude::*;
+
+pub(super) use self::factory::Factory;
+use self::messages::{SysinfoDropdownCmd, SysinfoDropdownInit, SysinfoDropdownInput};
+use crate::shell::bar::dropdowns::scaled_dimension;
+
+const BASE_WIDTH: f32 = 440.0;
+const BASE_HEIGHT: f32 = 630.0;
+
+pub(crate) struct SysinfoDropdown {
+    #[allow(dead_code)]
+    sysinfo: Arc<SysinfoService>,
+    #[allow(dead_code)]
+    config: Arc<ConfigService>,
+
+    scaled_width: i32,
+    scaled_height: i32,
+
+    // NVIDIA
+    nvidia_available: bool,
+    nvidia_name: String,
+    nvidia_usage: String,
+    nvidia_temp: String,
+    nvidia_vram: String,
+    nvidia_gpu_clock: String,
+    nvidia_mem_clock: String,
+    nvidia_fan: String,
+    nvidia_power: String,
+
+    // AMD iGPU
+    amd_available: bool,
+    amd_name: String,
+    amd_usage: String,
+    amd_temp: String,
+    amd_vram: String,
+
+    // CPU
+    cpu_name: String,
+    cpu_usage: String,
+    cpu_temp: String,
+    cpu_avg_freq: String,
+    cpu_max_freq: String,
+    cpu_cores: String,
+
+    // Memory
+    ram_info: String,
+    swap_info: String,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for SysinfoDropdown {
+    type Init = SysinfoDropdownInit;
+    type Input = SysinfoDropdownInput;
+    type Output = ();
+    type CommandOutput = SysinfoDropdownCmd;
+
+    view! {
+        #[root]
+        gtk::Popover {
+            set_css_classes: &["dropdown", "sysinfo-dropdown"],
+            set_has_arrow: false,
+            #[watch]
+            set_width_request: model.scaled_width,
+            #[watch]
+            set_height_request: model.scaled_height,
+
+            #[template]
+            Dropdown {
+
+                #[template]
+                DropdownHeader {
+                    #[template_child]
+                    icon {
+                        set_icon_name: Some("md-developer_board-symbolic"),
+                        set_visible: true,
+                    },
+                    #[template_child]
+                    label {
+                        set_label: "System Info",
+                    },
+                },
+
+                #[template]
+                DropdownContent {
+                    set_vexpand: true,
+
+                    gtk::ScrolledWindow {
+                        set_policy: (gtk::PolicyType::Never, gtk::PolicyType::Automatic),
+                        set_vexpand: true,
+
+                        gtk::Box {
+                            set_orientation: gtk::Orientation::Vertical,
+                            set_spacing: 8,
+                            set_margin_top: 4,
+                            set_margin_bottom: 8,
+
+                            // ── NVIDIA Card ─────────────────────────
+                            gtk::Box {
+                                add_css_class: "card",
+                                add_css_class: "sysinfo-card",
+                                set_orientation: gtk::Orientation::Vertical,
+                                #[watch]
+                                set_visible: model.nvidia_available,
+
+                                gtk::Box {
+                                    add_css_class: "sysinfo-card-header",
+                                    gtk::Image {
+                                        set_icon_name: Some("md-monitor-symbolic"),
+                                        add_css_class: "sysinfo-header-icon",
+                                        set_pixel_size: 18,
+                                    },
+                                    gtk::Label {
+                                        #[watch]
+                                        set_label: &model.nvidia_name,
+                                        add_css_class: "sysinfo-header-label",
+                                        set_wrap: true,
+                                        set_wrap_mode: gtk::pango::WrapMode::WordChar,
+                                    },
+                                },
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_spacing: 1,
+                                    add_css_class: "sysinfo-stat-list",
+
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Usage", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_usage, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Temp", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_temp, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "VRAM", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_vram, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "GPU Clock", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_gpu_clock, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Mem Clock", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_mem_clock, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Fan", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_fan, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Power", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.nvidia_power, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                },
+                            },
+
+                            // ── AMD iGPU Card ───────────────────────
+                            gtk::Box {
+                                add_css_class: "card",
+                                add_css_class: "sysinfo-card",
+                                set_orientation: gtk::Orientation::Vertical,
+                                #[watch]
+                                set_visible: model.amd_available,
+
+                                gtk::Box {
+                                    add_css_class: "sysinfo-card-header",
+                                    gtk::Image {
+                                        set_icon_name: Some("md-monitor-symbolic"),
+                                        add_css_class: "sysinfo-header-icon",
+                                        set_pixel_size: 18,
+                                    },
+                                    gtk::Label {
+                                        #[watch]
+                                        set_label: &model.amd_name,
+                                        add_css_class: "sysinfo-header-label",
+                                        set_wrap: true,
+                                        set_wrap_mode: gtk::pango::WrapMode::WordChar,
+                                    },
+                                },
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_spacing: 1,
+                                    add_css_class: "sysinfo-stat-list",
+
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Usage", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.amd_usage, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Temp", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.amd_temp, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "VRAM", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.amd_vram, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                },
+                            },
+
+                            // ── CPU Card ────────────────────────────
+                            gtk::Box {
+                                add_css_class: "card",
+                                add_css_class: "sysinfo-card",
+                                set_orientation: gtk::Orientation::Vertical,
+
+                                gtk::Box {
+                                    add_css_class: "sysinfo-card-header",
+                                    gtk::Image {
+                                        set_icon_name: Some("md-speed-symbolic"),
+                                        add_css_class: "sysinfo-header-icon",
+                                        set_pixel_size: 18,
+                                    },
+                                    gtk::Label {
+                                        #[watch]
+                                        set_label: &model.cpu_name,
+                                        add_css_class: "sysinfo-header-label",
+                                        set_wrap: true,
+                                        set_wrap_mode: gtk::pango::WrapMode::WordChar,
+                                    },
+                                },
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_spacing: 1,
+                                    add_css_class: "sysinfo-stat-list",
+
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Usage", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.cpu_usage, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Temp", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.cpu_temp, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Avg Freq", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.cpu_avg_freq, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Max Freq", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.cpu_max_freq, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Cores", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.cpu_cores, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                },
+                            },
+
+                            // ── Memory Card ─────────────────────────
+                            gtk::Box {
+                                add_css_class: "card",
+                                add_css_class: "sysinfo-card",
+                                set_orientation: gtk::Orientation::Vertical,
+
+                                gtk::Box {
+                                    add_css_class: "sysinfo-card-header",
+                                    gtk::Image {
+                                        set_icon_name: Some("md-memory-symbolic"),
+                                        add_css_class: "sysinfo-header-icon",
+                                        set_pixel_size: 18,
+                                    },
+                                    gtk::Label {
+                                        set_label: "MEMORY",
+                                        add_css_class: "sysinfo-header-label",
+                                    },
+                                },
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_spacing: 1,
+                                    add_css_class: "sysinfo-stat-list",
+
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "RAM", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.ram_info, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                    gtk::Box { add_css_class: "sysinfo-stat",
+                                        gtk::Label { set_label: "Swap", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                        gtk::Label { #[watch] set_label: &model.swap_info, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let scale = init.config.config().styling.scale.get().value();
+
+        // Detect available GPUs
+        let nvml = helpers::init_nvml();
+        let nvidia_available = nvml.is_some();
+        let amd_card = helpers::detect_amd_card();
+        let amd_available = amd_card.is_some();
+
+        // Read initial data
+        let nvidia = nvml
+            .as_ref()
+            .map(|n| helpers::read_nvidia(n, 0))
+            .unwrap_or_default();
+        let amd = amd_card.map(helpers::read_amd).unwrap_or_default();
+        let cpu_name = helpers::read_cpu_name();
+        let cpu_data = init.sysinfo.cpu.get();
+        let mem_data = init.sysinfo.memory.get();
+
+        let to_gb = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        watchers::spawn(
+            &sender,
+            &init.sysinfo,
+            &init.config,
+            nvml.map(Arc::new),
+            amd_card,
+            cpu_name.clone(),
+        );
+
+        let model = Self {
+            sysinfo: init.sysinfo,
+            config: init.config,
+
+            scaled_width: scaled_dimension(BASE_WIDTH, scale),
+            scaled_height: scaled_dimension(BASE_HEIGHT, scale),
+
+            nvidia_available,
+            nvidia_name: nvidia.name.clone(),
+            nvidia_usage: format!("{:.0}%", nvidia.usage_percent),
+            nvidia_temp: helpers::fmt_temp(nvidia.temperature_celsius),
+            nvidia_vram: helpers::fmt_vram(nvidia.vram_used_mb, nvidia.vram_total_mb),
+            nvidia_gpu_clock: helpers::fmt_clock(nvidia.gpu_clock_mhz),
+            nvidia_mem_clock: helpers::fmt_clock(nvidia.mem_clock_mhz),
+            nvidia_fan: helpers::fmt_fan(nvidia.fan_speed_percent),
+            nvidia_power: helpers::fmt_power(nvidia.power_watts, nvidia.power_limit_watts),
+
+            amd_available,
+            amd_name: amd.name.clone(),
+            amd_usage: format!("{:.0}%", amd.usage_percent),
+            amd_temp: helpers::fmt_temp(amd.temperature_celsius),
+            amd_vram: helpers::fmt_vram(amd.vram_used_mb, amd.vram_total_mb),
+
+            cpu_name,
+            cpu_usage: format!("{:.0}%", cpu_data.usage_percent),
+            cpu_temp: helpers::fmt_temp(cpu_data.temperature_celsius),
+            cpu_avg_freq: format!("{:.1} GHz", cpu_data.avg_frequency_mhz as f64 / 1000.0),
+            cpu_max_freq: format!("{:.1} GHz", cpu_data.max_frequency_mhz as f64 / 1000.0),
+            cpu_cores: cpu_data.cores.len().to_string(),
+
+            ram_info: helpers::fmt_gb(
+                to_gb(mem_data.used_bytes),
+                to_gb(mem_data.total_bytes),
+                mem_data.usage_percent,
+            ),
+            swap_info: helpers::fmt_gb(
+                to_gb(mem_data.swap_used_bytes),
+                to_gb(mem_data.swap_total_bytes),
+                mem_data.swap_percent,
+            ),
+        };
+
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, _msg: Self::Input, _sender: ComponentSender<Self>, _root: &Self::Root) {}
+
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            SysinfoDropdownCmd::ScaleChanged(scale) => {
+                self.scaled_width = scaled_dimension(BASE_WIDTH, scale);
+                self.scaled_height = scaled_dimension(BASE_HEIGHT, scale);
+            }
+
+            SysinfoDropdownCmd::UpdateNvidia(data) => {
+                self.nvidia_name = data.name;
+                self.nvidia_usage = format!("{:.0}%", data.usage_percent);
+                self.nvidia_temp = helpers::fmt_temp(data.temperature_celsius);
+                self.nvidia_vram = helpers::fmt_vram(data.vram_used_mb, data.vram_total_mb);
+                self.nvidia_gpu_clock = helpers::fmt_clock(data.gpu_clock_mhz);
+                self.nvidia_mem_clock = helpers::fmt_clock(data.mem_clock_mhz);
+                self.nvidia_fan = helpers::fmt_fan(data.fan_speed_percent);
+                self.nvidia_power = helpers::fmt_power(data.power_watts, data.power_limit_watts);
+            }
+
+            SysinfoDropdownCmd::UpdateAmd(data) => {
+                self.amd_name = data.name;
+                self.amd_usage = format!("{:.0}%", data.usage_percent);
+                self.amd_temp = helpers::fmt_temp(data.temperature_celsius);
+                self.amd_vram = helpers::fmt_vram(data.vram_used_mb, data.vram_total_mb);
+            }
+
+            SysinfoDropdownCmd::UpdateCpu(data) => {
+                self.cpu_name = data.name;
+                self.cpu_usage = format!("{:.0}%", data.usage_percent);
+                self.cpu_temp = helpers::fmt_temp(data.temperature_celsius);
+                self.cpu_avg_freq = format!("{:.1} GHz", data.avg_freq_ghz);
+                self.cpu_max_freq = format!("{:.1} GHz", data.max_freq_ghz);
+                self.cpu_cores = data.core_count.to_string();
+            }
+
+            SysinfoDropdownCmd::UpdateMemory(data) => {
+                self.ram_info = helpers::fmt_gb(data.ram_used_gb, data.ram_total_gb, data.ram_percent);
+                self.swap_info = helpers::fmt_gb(
+                    data.swap_used_gb,
+                    data.swap_total_gb,
+                    data.swap_percent,
+                );
+            }
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/sysinfo/watchers.rs
@@ -1,0 +1,111 @@
+use std::{sync::Arc, time::Duration};
+
+use nvml_wrapper::Nvml;
+use relm4::ComponentSender;
+use wayle_config::ConfigService;
+use wayle_sysinfo::SysinfoService;
+use wayle_widgets::watch;
+
+use super::{
+    SysinfoDropdown,
+    helpers::{self, CpuSummary, MemoryInfo},
+    messages::SysinfoDropdownCmd,
+};
+
+const GPU_POLL_MS: u64 = 3000;
+
+pub(super) fn spawn(
+    sender: &ComponentSender<SysinfoDropdown>,
+    sysinfo: &Arc<SysinfoService>,
+    config: &Arc<ConfigService>,
+    nvml: Option<Arc<Nvml>>,
+    amd_card: Option<u32>,
+    cpu_name: String,
+) {
+    spawn_scale_watcher(sender, config);
+    spawn_gpu_poller(sender, nvml, amd_card);
+    spawn_cpu_watcher(sender, sysinfo, cpu_name);
+    spawn_memory_watcher(sender, sysinfo);
+}
+
+fn spawn_scale_watcher(
+    sender: &ComponentSender<SysinfoDropdown>,
+    config: &Arc<ConfigService>,
+) {
+    let scale = config.config().styling.scale.clone();
+
+    watch!(sender, [scale.watch()], |out| {
+        let _ = out.send(SysinfoDropdownCmd::ScaleChanged(scale.get().value()));
+    });
+}
+
+fn spawn_gpu_poller(
+    sender: &ComponentSender<SysinfoDropdown>,
+    nvml: Option<Arc<Nvml>>,
+    amd_card: Option<u32>,
+) {
+    let poll_interval = Duration::from_millis(GPU_POLL_MS);
+
+    sender.command(move |out, shutdown| {
+        shutdown
+            .register(async move {
+                loop {
+                    if let Some(ref nvml) = nvml {
+                        let data = helpers::read_nvidia(nvml, 0);
+                        let _ = out.send(SysinfoDropdownCmd::UpdateNvidia(data));
+                    }
+
+                    if let Some(card) = amd_card {
+                        let data = helpers::read_amd(card);
+                        let _ = out.send(SysinfoDropdownCmd::UpdateAmd(data));
+                    }
+
+                    tokio::time::sleep(poll_interval).await;
+                }
+            })
+            .drop_on_shutdown()
+    });
+}
+
+fn spawn_cpu_watcher(
+    sender: &ComponentSender<SysinfoDropdown>,
+    sysinfo: &Arc<SysinfoService>,
+    cpu_name: String,
+) {
+    let cpu_prop = sysinfo.cpu.clone();
+
+    watch!(sender, [cpu_prop.watch()], |out| {
+        let cpu = cpu_prop.get();
+        let summary = CpuSummary {
+            name: cpu_name.clone(),
+            usage_percent: cpu.usage_percent,
+            temperature_celsius: cpu.temperature_celsius,
+            avg_freq_ghz: cpu.avg_frequency_mhz as f64 / 1000.0,
+            max_freq_ghz: cpu.max_frequency_mhz as f64 / 1000.0,
+            core_count: cpu.cores.len(),
+        };
+        let _ = out.send(SysinfoDropdownCmd::UpdateCpu(summary));
+    });
+}
+
+fn spawn_memory_watcher(
+    sender: &ComponentSender<SysinfoDropdown>,
+    sysinfo: &Arc<SysinfoService>,
+) {
+    let mem_prop = sysinfo.memory.clone();
+
+    watch!(sender, [mem_prop.watch()], |out| {
+        let mem = mem_prop.get();
+        let to_gb = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        let info = MemoryInfo {
+            ram_used_gb: to_gb(mem.used_bytes),
+            ram_total_gb: to_gb(mem.total_bytes),
+            ram_percent: mem.usage_percent,
+            swap_used_gb: to_gb(mem.swap_used_bytes),
+            swap_total_gb: to_gb(mem.swap_total_bytes),
+            swap_percent: mem.swap_percent,
+        };
+        let _ = out.send(SysinfoDropdownCmd::UpdateMemory(info));
+    });
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/factory.rs
@@ -1,0 +1,21 @@
+use relm4::prelude::*;
+
+use super::{UpdatesDropdown, messages::UpdatesDropdownInit};
+use crate::shell::{
+    bar::dropdowns::{DropdownFactory, DropdownInstance},
+    services::ShellServices,
+};
+
+pub(crate) struct Factory;
+
+impl DropdownFactory for Factory {
+    fn create(services: &ShellServices) -> Option<DropdownInstance> {
+        let config = services.config.clone();
+
+        let init = UpdatesDropdownInit { config };
+        let controller = UpdatesDropdown::builder().launch(init).detach();
+
+        let popover = controller.widget().clone();
+        Some(DropdownInstance::new(popover, Box::new(controller)))
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
@@ -25,9 +25,10 @@ pub(super) async fn run_count_command(command: &str) -> u32 {
     }
 }
 
-/// Spawn the update command in the user's terminal.
-/// Returns false if an update is already running.
-pub(super) fn spawn_update_in_terminal(update_command: &str) -> bool {
+/// Spawn the update command in the user's terminal and wait for it to finish.
+/// Returns false immediately if an update is already running.
+/// Returns true after the terminal process exits.
+pub(super) async fn spawn_update_in_terminal(update_command: &str) -> bool {
     use std::sync::atomic::{AtomicBool, Ordering};
     static RUNNING: AtomicBool = AtomicBool::new(false);
 
@@ -50,38 +51,34 @@ pub(super) fn spawn_update_in_terminal(update_command: &str) -> bool {
         ("xterm", vec!["-e", "sh", "-c"]),
     ];
 
-    tokio::spawn(async move {
-        for (term, args) in &terminals {
-            if let Ok(check) = tokio::process::Command::new("which")
-                .arg(term)
-                .output()
-                .await
-            {
-                if check.status.success() {
-                    let mut full_args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
-                    full_args.push(&wrapped);
+    for (term, args) in &terminals {
+        if let Ok(check) = tokio::process::Command::new("which")
+            .arg(term)
+            .output()
+            .await
+        {
+            if check.status.success() {
+                let mut full_args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
+                full_args.push(&wrapped);
 
-                    match tokio::process::Command::new(term)
-                        .args(&full_args)
-                        .spawn()
-                    {
-                        Ok(mut child) => {
-                            // Wait for terminal to close before allowing another
-                            let _ = child.wait().await;
-                            RUNNING.store(false, Ordering::SeqCst);
-                            return;
-                        }
-                        Err(e) => {
-                            tracing::warn!("failed to spawn {term}: {e}");
-                        }
+                match tokio::process::Command::new(term)
+                    .args(&full_args)
+                    .spawn()
+                {
+                    Ok(mut child) => {
+                        let _ = child.wait().await;
+                        RUNNING.store(false, Ordering::SeqCst);
+                        return true;
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to spawn {term}: {e}");
                     }
                 }
             }
         }
+    }
 
-        tracing::warn!("no terminal emulator found to run update command");
-        RUNNING.store(false, Ordering::SeqCst);
-    });
-
-    true
+    tracing::warn!("no terminal emulator found to run update command");
+    RUNNING.store(false, Ordering::SeqCst);
+    false
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
@@ -1,0 +1,60 @@
+/// Run a shell command and parse the trimmed stdout as a u32 count.
+pub(super) async fn run_count_command(command: &str) -> u32 {
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .output()
+        .await;
+
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let trimmed = stdout.trim();
+            let count = trimmed.parse::<u32>().unwrap_or(0);
+            tracing::debug!(
+                "updates dropdown cmd `{}` → stdout={:?} stderr={:?} count={}",
+                command, trimmed, stderr.trim(), count
+            );
+            count
+        }
+        Err(e) => {
+            tracing::warn!("updates dropdown check command failed: {e}");
+            0
+        }
+    }
+}
+
+/// Spawn the update command in the user's terminal.
+pub(super) fn spawn_update_in_terminal(update_command: &str) {
+    let cmd = update_command.to_string();
+    tokio::spawn(async move {
+        // Try common terminals in order of preference
+        let terminals = [
+            ("kitty", vec!["-e", "sh", "-c"]),
+            ("foot", vec!["-e", "sh", "-c"]),
+            ("alacritty", vec!["-e", "sh", "-c"]),
+            ("wezterm", vec!["start", "--", "sh", "-c"]),
+            ("xterm", vec!["-e", "sh", "-c"]),
+        ];
+
+        for (term, args) in &terminals {
+            if let Ok(path) = tokio::process::Command::new("which")
+                .arg(term)
+                .output()
+                .await
+            {
+                if path.status.success() {
+                    let mut full_args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
+                    full_args.push(&cmd);
+                    let _ = tokio::process::Command::new(term)
+                        .args(&full_args)
+                        .spawn();
+                    return;
+                }
+            }
+        }
+
+        tracing::warn!("no terminal emulator found to run update command");
+    });
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/helpers.rs
@@ -26,35 +26,62 @@ pub(super) async fn run_count_command(command: &str) -> u32 {
 }
 
 /// Spawn the update command in the user's terminal.
-pub(super) fn spawn_update_in_terminal(update_command: &str) {
-    let cmd = update_command.to_string();
-    tokio::spawn(async move {
-        // Try common terminals in order of preference
-        let terminals = [
-            ("kitty", vec!["-e", "sh", "-c"]),
-            ("foot", vec!["-e", "sh", "-c"]),
-            ("alacritty", vec!["-e", "sh", "-c"]),
-            ("wezterm", vec!["start", "--", "sh", "-c"]),
-            ("xterm", vec!["-e", "sh", "-c"]),
-        ];
+/// Returns false if an update is already running.
+pub(super) fn spawn_update_in_terminal(update_command: &str) -> bool {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static RUNNING: AtomicBool = AtomicBool::new(false);
 
+    if RUNNING.swap(true, Ordering::SeqCst) {
+        tracing::debug!("update already running, ignoring click");
+        return false;
+    }
+
+    // Wrap command so terminal stays open after finish/failure
+    let wrapped = format!(
+        "{cmd}; echo ''; echo 'Press enter to close...'; read",
+        cmd = update_command
+    );
+
+    let terminals = [
+        ("kitty", vec!["-e", "sh", "-c"]),
+        ("foot", vec!["-e", "sh", "-c"]),
+        ("alacritty", vec!["-e", "sh", "-c"]),
+        ("wezterm", vec!["start", "--", "sh", "-c"]),
+        ("xterm", vec!["-e", "sh", "-c"]),
+    ];
+
+    tokio::spawn(async move {
         for (term, args) in &terminals {
-            if let Ok(path) = tokio::process::Command::new("which")
+            if let Ok(check) = tokio::process::Command::new("which")
                 .arg(term)
                 .output()
                 .await
             {
-                if path.status.success() {
+                if check.status.success() {
                     let mut full_args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
-                    full_args.push(&cmd);
-                    let _ = tokio::process::Command::new(term)
+                    full_args.push(&wrapped);
+
+                    match tokio::process::Command::new(term)
                         .args(&full_args)
-                        .spawn();
-                    return;
+                        .spawn()
+                    {
+                        Ok(mut child) => {
+                            // Wait for terminal to close before allowing another
+                            let _ = child.wait().await;
+                            RUNNING.store(false, Ordering::SeqCst);
+                            return;
+                        }
+                        Err(e) => {
+                            tracing::warn!("failed to spawn {term}: {e}");
+                        }
+                    }
                 }
             }
         }
 
         tracing::warn!("no terminal emulator found to run update command");
+        RUNNING.store(false, Ordering::SeqCst);
     });
+
+    true
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/messages.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use wayle_config::ConfigService;
+
+pub(crate) struct UpdatesDropdownInit {
+    pub config: Arc<ConfigService>,
+}
+
+#[derive(Debug)]
+pub(crate) enum UpdatesDropdownInput {
+    Refresh,
+    UpdateAll,
+}
+
+#[derive(Debug)]
+pub(crate) enum UpdatesDropdownCmd {
+    ScaleChanged(f32),
+    UpdateCounts { pacman: u32, aur: u32, flatpak: u32 },
+    SetChecking(bool),
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/mod.rs
@@ -228,9 +228,12 @@ impl Component for UpdatesDropdown {
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
+    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, root: &Self::Root) {
         match msg {
             UpdatesDropdownInput::Refresh => {
+                // Re-show popover (GTK may close it on button activation)
+                root.popup();
+
                 self.status_text = String::from("Checking for updates...");
                 self.pacman_count = String::from("...");
                 self.aur_count = String::from("...");
@@ -254,13 +257,42 @@ impl Component for UpdatesDropdown {
 
                             let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak });
                             let _ = out.send(UpdatesDropdownCmd::SetChecking(false));
+
+                            // Signal bar module to update its label too
+                            crate::shell::bar::modules::updates::helpers::REFRESH_NOTIFY.notify_one();
                         })
                         .drop_on_shutdown()
                 });
             }
             UpdatesDropdownInput::UpdateAll => {
                 let update_cmd = self.config.config().modules.updates.update_command.get().clone();
-                helpers::spawn_update_in_terminal(&update_cmd);
+                let official_cmd = self.config.config().modules.updates.check_official_command.get().clone();
+                let aur_cmd = self.config.config().modules.updates.check_aur_command.get().clone();
+                let flatpak_cmd = self.config.config().modules.updates.check_flatpak_command.get().clone();
+
+                sender.command(move |out, shutdown| {
+                    shutdown
+                        .register(async move {
+                            // Wait for terminal to close
+                            if helpers::spawn_update_in_terminal(&update_cmd).await {
+                                // Re-check counts after update finished
+                                let _ = out.send(UpdatesDropdownCmd::SetChecking(true));
+
+                                let (pacman, aur, flatpak) = tokio::join!(
+                                    helpers::run_count_command(&official_cmd),
+                                    helpers::run_count_command(&aur_cmd),
+                                    helpers::run_count_command(&flatpak_cmd),
+                                );
+
+                                let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak });
+                                let _ = out.send(UpdatesDropdownCmd::SetChecking(false));
+
+                                // Signal bar module to update its label
+                                crate::shell::bar::modules::updates::helpers::REFRESH_NOTIFY.notify_one();
+                            }
+                        })
+                        .drop_on_shutdown()
+                });
             }
         }
     }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/mod.rs
@@ -1,0 +1,295 @@
+mod factory;
+mod helpers;
+mod messages;
+mod watchers;
+
+use std::sync::Arc;
+
+use gtk::prelude::*;
+use relm4::{gtk, prelude::*};
+use wayle_config::ConfigService;
+use wayle_widgets::prelude::*;
+
+pub(super) use self::factory::Factory;
+use self::messages::{UpdatesDropdownCmd, UpdatesDropdownInit, UpdatesDropdownInput};
+use crate::shell::bar::dropdowns::scaled_dimension;
+
+const BASE_WIDTH: f32 = 340.0;
+const BASE_HEIGHT: f32 = 310.0;
+
+pub(crate) struct UpdatesDropdown {
+    #[allow(dead_code)]
+    config: Arc<ConfigService>,
+
+    scaled_width: i32,
+    scaled_height: i32,
+
+    pacman_count: String,
+    aur_count: String,
+    flatpak_count: String,
+    total_count: String,
+    status_text: String,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for UpdatesDropdown {
+    type Init = UpdatesDropdownInit;
+    type Input = UpdatesDropdownInput;
+    type Output = ();
+    type CommandOutput = UpdatesDropdownCmd;
+
+    view! {
+        #[root]
+        gtk::Popover {
+            set_css_classes: &["dropdown", "sysinfo-dropdown"],
+            set_has_arrow: false,
+            #[watch]
+            set_width_request: model.scaled_width,
+            #[watch]
+            set_height_request: model.scaled_height,
+
+            #[template]
+            Dropdown {
+
+                #[template]
+                DropdownHeader {
+                    #[template_child]
+                    icon {
+                        set_icon_name: Some("md-package_2-symbolic"),
+                        set_visible: true,
+                    },
+                    #[template_child]
+                    label {
+                        set_label: "System Updates",
+                    },
+                },
+
+                #[template]
+                DropdownContent {
+                    set_vexpand: true,
+
+                    gtk::Box {
+                        set_orientation: gtk::Orientation::Vertical,
+                        set_spacing: 8,
+                        set_margin_top: 4,
+                        set_margin_bottom: 8,
+
+                        // ── Update Counts Card ──────────────────
+                        gtk::Box {
+                            add_css_class: "card",
+                            add_css_class: "sysinfo-card",
+                            set_orientation: gtk::Orientation::Vertical,
+
+                            gtk::Box {
+                                add_css_class: "sysinfo-card-header",
+                                gtk::Image {
+                                    set_icon_name: Some("md-inventory_2-symbolic"),
+                                    add_css_class: "sysinfo-header-icon",
+                                    set_pixel_size: 18,
+                                },
+                                gtk::Label {
+                                    set_label: "PACKAGES",
+                                    add_css_class: "sysinfo-header-label",
+                                },
+                            },
+
+                            gtk::Box {
+                                set_orientation: gtk::Orientation::Vertical,
+                                set_spacing: 1,
+                                add_css_class: "sysinfo-stat-list",
+
+                                gtk::Box { add_css_class: "sysinfo-stat",
+                                    gtk::Label { set_label: "Official", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                    gtk::Label { #[watch] set_label: &model.pacman_count, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                },
+                                gtk::Box { add_css_class: "sysinfo-stat",
+                                    gtk::Label { set_label: "AUR", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                    gtk::Label { #[watch] set_label: &model.aur_count, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                },
+                                gtk::Box { add_css_class: "sysinfo-stat",
+                                    gtk::Label { set_label: "Flatpak", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                    gtk::Label { #[watch] set_label: &model.flatpak_count, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                },
+                                gtk::Separator {},
+                                gtk::Box { add_css_class: "sysinfo-stat",
+                                    gtk::Label { set_label: "Total", add_css_class: "sysinfo-stat-key", set_hexpand: true, set_xalign: 0.0, },
+                                    gtk::Label { #[watch] set_label: &model.total_count, add_css_class: "sysinfo-stat-val", set_xalign: 1.0, },
+                                },
+                            },
+                        },
+
+                        // ── Status ──────────────────────────────
+                        gtk::Label {
+                            #[watch]
+                            set_label: &model.status_text,
+                            add_css_class: "sysinfo-stat-key",
+                            set_xalign: 0.5,
+                            #[watch]
+                            set_visible: !model.status_text.is_empty(),
+                        },
+
+                        // ── Action Buttons Card ─────────────────
+                        gtk::Box {
+                            add_css_class: "card",
+                            add_css_class: "sysinfo-card",
+                            set_orientation: gtk::Orientation::Horizontal,
+                            set_homogeneous: true,
+                            set_spacing: 8,
+                            set_margin_start: 4,
+                            set_margin_end: 4,
+                            set_margin_top: 4,
+                            set_margin_bottom: 8,
+
+                            gtk::Button {
+                                add_css_class: "quick-action",
+                                set_hexpand: true,
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_halign: gtk::Align::Center,
+                                    set_valign: gtk::Align::Center,
+                                    set_spacing: 4,
+
+                                    gtk::Box {
+                                        add_css_class: "quick-action-icon",
+                                        set_halign: gtk::Align::Center,
+                                        gtk::Image {
+                                            set_icon_name: Some("md-deployed_code_update-symbolic"),
+                                            set_pixel_size: 24,
+                                        },
+                                    },
+                                    gtk::Label {
+                                        set_label: "Refresh",
+                                        add_css_class: "quick-action-label",
+                                        set_halign: gtk::Align::Center,
+                                    },
+                                },
+
+                                connect_clicked => UpdatesDropdownInput::Refresh,
+                            },
+
+                            gtk::Button {
+                                add_css_class: "quick-action",
+                                set_hexpand: true,
+
+                                gtk::Box {
+                                    set_orientation: gtk::Orientation::Vertical,
+                                    set_halign: gtk::Align::Center,
+                                    set_valign: gtk::Align::Center,
+                                    set_spacing: 4,
+
+                                    gtk::Box {
+                                        add_css_class: "quick-action-icon",
+                                        set_halign: gtk::Align::Center,
+                                        gtk::Image {
+                                            set_icon_name: Some("md-download-symbolic"),
+                                            set_pixel_size: 24,
+                                        },
+                                    },
+                                    gtk::Label {
+                                        set_label: "Update All",
+                                        add_css_class: "quick-action-label",
+                                        set_halign: gtk::Align::Center,
+                                    },
+                                },
+
+                                connect_clicked => UpdatesDropdownInput::UpdateAll,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let scale = init.config.config().styling.scale.get().value();
+
+        watchers::spawn(&sender, &init.config);
+
+        let model = Self {
+            config: init.config,
+
+            scaled_width: scaled_dimension(BASE_WIDTH, scale),
+            scaled_height: scaled_dimension(BASE_HEIGHT, scale),
+
+            pacman_count: String::from("..."),
+            aur_count: String::from("..."),
+            flatpak_count: String::from("..."),
+            total_count: String::from("..."),
+            status_text: String::from("Checking for updates..."),
+        };
+
+        let widgets = view_output!();
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
+        match msg {
+            UpdatesDropdownInput::Refresh => {
+                self.status_text = String::from("Checking for updates...");
+                self.pacman_count = String::from("...");
+                self.aur_count = String::from("...");
+                self.flatpak_count = String::from("...");
+                self.total_count = String::from("...");
+
+                let official_cmd = self.config.config().modules.updates.check_official_command.get().clone();
+                let aur_cmd = self.config.config().modules.updates.check_aur_command.get().clone();
+                let flatpak_cmd = self.config.config().modules.updates.check_flatpak_command.get().clone();
+
+                sender.command(move |out, shutdown| {
+                    shutdown
+                        .register(async move {
+                            let _ = out.send(UpdatesDropdownCmd::SetChecking(true));
+
+                            let (pacman, aur, flatpak) = tokio::join!(
+                                helpers::run_count_command(&official_cmd),
+                                helpers::run_count_command(&aur_cmd),
+                                helpers::run_count_command(&flatpak_cmd),
+                            );
+
+                            let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak });
+                            let _ = out.send(UpdatesDropdownCmd::SetChecking(false));
+                        })
+                        .drop_on_shutdown()
+                });
+            }
+            UpdatesDropdownInput::UpdateAll => {
+                let update_cmd = self.config.config().modules.updates.update_command.get().clone();
+                helpers::spawn_update_in_terminal(&update_cmd);
+            }
+        }
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            UpdatesDropdownCmd::ScaleChanged(scale) => {
+                self.scaled_width = scaled_dimension(BASE_WIDTH, scale);
+                self.scaled_height = scaled_dimension(BASE_HEIGHT, scale);
+            }
+            UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak } => {
+                let total = pacman + aur + flatpak;
+                self.pacman_count = pacman.to_string();
+                self.aur_count = aur.to_string();
+                self.flatpak_count = flatpak.to_string();
+                self.total_count = total.to_string();
+            }
+            UpdatesDropdownCmd::SetChecking(checking) => {
+                if checking {
+                    self.status_text = String::from("Checking for updates...");
+                } else {
+                    self.status_text = String::new();
+                }
+            }
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/updates/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/updates/watchers.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use relm4::ComponentSender;
+use wayle_config::ConfigService;
+use wayle_widgets::watch;
+
+use super::{UpdatesDropdown, helpers, messages::UpdatesDropdownCmd};
+
+pub(super) fn spawn(
+    sender: &ComponentSender<UpdatesDropdown>,
+    config: &Arc<ConfigService>,
+) {
+    spawn_scale_watcher(sender, config);
+    spawn_initial_check(sender, config);
+}
+
+fn spawn_scale_watcher(
+    sender: &ComponentSender<UpdatesDropdown>,
+    config: &Arc<ConfigService>,
+) {
+    let scale = config.config().styling.scale.clone();
+
+    watch!(sender, [scale.watch()], |out| {
+        let _ = out.send(UpdatesDropdownCmd::ScaleChanged(scale.get().value()));
+    });
+}
+
+fn spawn_initial_check(
+    sender: &ComponentSender<UpdatesDropdown>,
+    config: &Arc<ConfigService>,
+) {
+    let official_cmd = config.config().modules.updates.check_official_command.get().clone();
+    let aur_cmd = config.config().modules.updates.check_aur_command.get().clone();
+    let flatpak_cmd = config.config().modules.updates.check_flatpak_command.get().clone();
+
+    sender.command(move |out, shutdown| {
+        shutdown
+            .register(async move {
+                let _ = out.send(UpdatesDropdownCmd::SetChecking(true));
+
+                let (pacman, aur, flatpak) = tokio::join!(
+                    helpers::run_count_command(&official_cmd),
+                    helpers::run_count_command(&aur_cmd),
+                    helpers::run_count_command(&flatpak_cmd),
+                );
+
+                // If official returned 0 but others didn't, retry after delay
+                // (checkupdates may fail on startup due to network not ready)
+                if pacman == 0 && (aur > 0 || flatpak > 0) {
+                    tracing::debug!("dropdown: official count was 0, retrying in 30s");
+                    let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak });
+
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+                    let pacman_retry = helpers::run_count_command(&official_cmd).await;
+                    let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman: pacman_retry, aur, flatpak });
+                } else {
+                    let _ = out.send(UpdatesDropdownCmd::UpdateCounts { pacman, aur, flatpak });
+                }
+
+                let _ = out.send(UpdatesDropdownCmd::SetChecking(false));
+            })
+            .drop_on_shutdown()
+    });
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/factory.rs
@@ -1,0 +1,32 @@
+use std::rc::Rc;
+
+use relm4::prelude::*;
+use wayle_widgets::prelude::BarSettings;
+
+use super::{GpuInit, GpuModule};
+use crate::shell::{
+    bar::{
+        dropdowns::DropdownRegistry,
+        modules::registry::{ModuleFactory, ModuleInstance, dynamic_controller},
+    },
+    services::ShellServices,
+};
+
+pub(crate) struct Factory;
+
+impl ModuleFactory for Factory {
+    fn create(
+        settings: &BarSettings,
+        services: &ShellServices,
+        dropdowns: &Rc<DropdownRegistry>,
+        class: Option<String>,
+    ) -> Option<ModuleInstance> {
+        let init = GpuInit {
+            settings: settings.clone(),
+            config: services.config.clone(),
+            dropdowns: dropdowns.clone(),
+        };
+        let controller = dynamic_controller(GpuModule::builder().launch(init).detach());
+        Some(ModuleInstance { controller, class })
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/helpers.rs
@@ -1,0 +1,263 @@
+use nvml_wrapper::Nvml;
+use serde_json::json;
+use tracing::warn;
+
+/// Raw GPU data from sysfs or NVML.
+#[derive(Debug, Clone, Default)]
+pub(super) struct GpuData {
+    pub usage_percent: f32,
+    pub temperature_celsius: Option<f32>,
+    pub vram_used_mb: u64,
+    pub vram_total_mb: u64,
+    pub name: String,
+}
+
+impl GpuData {
+    pub fn vram_percent(&self) -> f32 {
+        if self.vram_total_mb == 0 {
+            return 0.0;
+        }
+        (self.vram_used_mb as f32 / self.vram_total_mb as f32) * 100.0
+    }
+}
+
+/// Formats a GPU label using Jinja2 template syntax.
+///
+/// ## Variables
+///
+/// - `{{ percent }}` - GPU usage (00-100, zero-padded)
+/// - `{{ temp_c }}` - Temperature in Celsius (zero-padded)
+/// - `{{ temp_f }}` - Temperature in Fahrenheit (zero-padded)
+/// - `{{ vram_used_mb }}` - VRAM used in MB
+/// - `{{ vram_total_mb }}` - VRAM total in MB
+/// - `{{ vram_percent }}` - VRAM usage percentage
+/// - `{{ name }}` - GPU model name
+pub(super) fn format_label(format: &str, gpu: &GpuData) -> String {
+    let temp_c = gpu.temperature_celsius.unwrap_or(0.0);
+    let temp_f = temp_c * 9.0 / 5.0 + 32.0;
+
+    let ctx = json!({
+        "percent": format!("{:02.0}", gpu.usage_percent),
+        "temp_c": format!("{temp_c:02.0}"),
+        "temp_f": format!("{temp_f:02.0}"),
+        "vram_used_mb": gpu.vram_used_mb,
+        "vram_total_mb": gpu.vram_total_mb,
+        "vram_percent": format!("{:.0}", gpu.vram_percent()),
+        "name": &gpu.name,
+    });
+    crate::template::render(format, ctx).unwrap_or_default()
+}
+
+/// Detected GPU vendor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GpuVendor {
+    Nvidia,
+    Amd,
+    Unknown,
+}
+
+/// Attempt to initialise the NVML library.
+///
+/// Returns `Some(Nvml)` when the NVIDIA driver is installed and
+/// `libnvidia-ml.so` can be loaded.  Returns `None` otherwise.
+pub(super) fn init_nvml() -> Option<Nvml> {
+    match Nvml::init() {
+        Ok(nvml) => Some(nvml),
+        Err(e) => {
+            tracing::debug!("NVML init failed (expected on non-NVIDIA systems): {e}");
+            None
+        }
+    }
+}
+
+/// Auto-detect GPU vendor.
+///
+/// When `vendor_config` is `"auto"`, the presence of a successfully
+/// initialised NVML handle indicates NVIDIA; otherwise AMD sysfs is probed.
+pub(super) fn detect_vendor(vendor_config: &str, nvml: &Option<Nvml>) -> GpuVendor {
+    match vendor_config {
+        "nvidia" => GpuVendor::Nvidia,
+        "amd" => GpuVendor::Amd,
+        "auto" | _ => {
+            // NVML was already initialised — NVIDIA driver is present
+            if nvml.is_some() {
+                return GpuVendor::Nvidia;
+            }
+
+            // Check AMD (sysfs gpu_busy_percent exists)
+            for entry in std::fs::read_dir("/sys/class/drm/").into_iter().flatten() {
+                let Ok(entry) = entry else { continue };
+                let path = entry.path().join("device/gpu_busy_percent");
+                if path.exists() {
+                    return GpuVendor::Amd;
+                }
+            }
+
+            GpuVendor::Unknown
+        }
+    }
+}
+
+/// Read GPU data from NVIDIA via NVML.
+pub(super) fn read_nvidia(nvml: &Nvml, device_index: u32) -> GpuData {
+    let device = match nvml.device_by_index(device_index) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!("NVML: failed to get device {device_index}: {e}");
+            return GpuData::default();
+        }
+    };
+
+    let usage_percent = device
+        .utilization_rates()
+        .map(|u| u.gpu as f32)
+        .unwrap_or(0.0);
+
+    let temperature_celsius = device
+        .temperature(nvml_wrapper::enum_wrappers::device::TemperatureSensor::Gpu)
+        .ok()
+        .map(|t| t as f32);
+
+    let (vram_used_mb, vram_total_mb) = device
+        .memory_info()
+        .map(|m| (m.used / (1024 * 1024), m.total / (1024 * 1024)))
+        .unwrap_or((0, 0));
+
+    let name = device.name().unwrap_or_default();
+
+    GpuData {
+        usage_percent,
+        temperature_celsius,
+        vram_used_mb,
+        vram_total_mb,
+        name,
+    }
+}
+
+/// Read GPU data from AMD sysfs/hwmon.
+pub(super) fn read_amd(card_index: u32) -> GpuData {
+    let card = format!("/sys/class/drm/card{card_index}/device");
+
+    let usage = read_sysfs_u64(&format!("{card}/gpu_busy_percent")).unwrap_or(0);
+    let vram_used = read_sysfs_u64(&format!("{card}/mem_info_vram_used")).unwrap_or(0);
+    let vram_total = read_sysfs_u64(&format!("{card}/mem_info_vram_total")).unwrap_or(0);
+
+    // Temperature from hwmon (millidegrees Celsius)
+    let temp = find_hwmon_temp(&card);
+
+    // GPU name from product info or marketing name
+    let name = read_sysfs_string(&format!("{card}/product_name"))
+        .or_else(|| read_sysfs_string(&format!("{card}/marketing_name")))
+        .unwrap_or_default();
+
+    GpuData {
+        usage_percent: usage as f32,
+        temperature_celsius: temp,
+        vram_used_mb: vram_used / (1024 * 1024),
+        vram_total_mb: vram_total / (1024 * 1024),
+        name,
+    }
+}
+
+fn find_hwmon_temp(card_device_path: &str) -> Option<f32> {
+    let hwmon_dir = format!("{card_device_path}/hwmon");
+    let entries = std::fs::read_dir(&hwmon_dir).ok()?;
+
+    for entry in entries.flatten() {
+        let temp_path = entry.path().join("temp1_input");
+        if let Some(millideg) = read_sysfs_u64(&temp_path.to_string_lossy()) {
+            return Some(millideg as f32 / 1000.0);
+        }
+    }
+    None
+}
+
+fn read_sysfs_u64(path: &str) -> Option<u64> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn read_sysfs_string(path: &str) -> Option<String> {
+    let s = std::fs::read_to_string(path).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gpu_data(usage: f32, temp: Option<f32>, vram_used: u64, vram_total: u64) -> GpuData {
+        GpuData {
+            usage_percent: usage,
+            temperature_celsius: temp,
+            vram_used_mb: vram_used,
+            vram_total_mb: vram_total,
+            name: String::from("Test GPU"),
+        }
+    }
+
+    #[test]
+    fn format_label_replaces_percent() {
+        let gpu = gpu_data(45.7, Some(55.0), 2048, 8192);
+        let result = format_label("{{ percent }}%", &gpu);
+        assert_eq!(result, "46%");
+    }
+
+    #[test]
+    fn format_label_percent_pads_single_digits() {
+        let gpu = gpu_data(5.2, Some(55.0), 2048, 8192);
+        let result = format_label("{{ percent }}", &gpu);
+        assert_eq!(result, "05");
+    }
+
+    #[test]
+    fn format_label_replaces_temp_c() {
+        let gpu = gpu_data(50.0, Some(72.5), 2048, 8192);
+        let result = format_label("{{ temp_c }}°C", &gpu);
+        assert_eq!(result, "72°C");
+    }
+
+    #[test]
+    fn format_label_replaces_vram() {
+        let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
+        let result = format_label("{{ vram_used_mb }}/{{ vram_total_mb }}MB", &gpu);
+        assert_eq!(result, "2048/8192MB");
+    }
+
+    #[test]
+    fn format_label_replaces_vram_percent() {
+        let gpu = gpu_data(50.0, Some(55.0), 4096, 8192);
+        let result = format_label("{{ vram_percent }}%", &gpu);
+        assert_eq!(result, "50%");
+    }
+
+    #[test]
+    fn format_label_replaces_name() {
+        let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
+        let result = format_label("{{ name }}", &gpu);
+        assert_eq!(result, "Test GPU");
+    }
+
+    #[test]
+    fn format_label_with_no_temp_uses_zero() {
+        let gpu = gpu_data(50.0, None, 2048, 8192);
+        let result = format_label("{{ temp_c }}°C", &gpu);
+        assert_eq!(result, "00°C");
+    }
+
+    #[test]
+    fn format_label_multiple_placeholders() {
+        let gpu = gpu_data(75.0, Some(65.0), 4096, 8192);
+        let result = format_label("{{ percent }}% {{ temp_c }}°C {{ vram_percent }}%V", &gpu);
+        assert_eq!(result, "75% 65°C 50%V");
+    }
+
+    #[test]
+    fn vram_percent_zero_total() {
+        let gpu = gpu_data(0.0, None, 0, 0);
+        assert_eq!(gpu.vram_percent(), 0.0);
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/helpers.rs
@@ -1,6 +1,7 @@
 use nvml_wrapper::Nvml;
 use serde_json::json;
 use tracing::warn;
+use wayle_sysinfo::types::MemoryData;
 
 /// Raw GPU data from sysfs or NVML.
 #[derive(Debug, Clone, Default)]
@@ -32,9 +33,23 @@ impl GpuData {
 /// - `{{ vram_total_mb }}` - VRAM total in MB
 /// - `{{ vram_percent }}` - VRAM usage percentage
 /// - `{{ name }}` - GPU model name
-pub(super) fn format_label(format: &str, gpu: &GpuData) -> String {
+/// - `{{ ram_used_gb }}` - System RAM used in GB (1 decimal)
+/// - `{{ ram_total_gb }}` - System RAM total in GB (1 decimal)
+/// - `{{ ram_available_gb }}` - System RAM available in GB (1 decimal)
+/// - `{{ ram_percent }}` - System RAM usage percentage (zero-padded)
+pub(super) fn format_label(format: &str, gpu: &GpuData, mem: Option<&MemoryData>) -> String {
     let temp_c = gpu.temperature_celsius.unwrap_or(0.0);
     let temp_f = temp_c * 9.0 / 5.0 + 32.0;
+
+    let (ram_used_gb, ram_total_gb, ram_available_gb, ram_percent) = match mem {
+        Some(m) => (
+            m.used_bytes as f64 / 1_073_741_824.0,
+            m.total_bytes as f64 / 1_073_741_824.0,
+            m.available_bytes as f64 / 1_073_741_824.0,
+            m.usage_percent as f64,
+        ),
+        None => (0.0, 0.0, 0.0, 0.0),
+    };
 
     let ctx = json!({
         "percent": format!("{:02.0}", gpu.usage_percent),
@@ -44,6 +59,10 @@ pub(super) fn format_label(format: &str, gpu: &GpuData) -> String {
         "vram_total_mb": gpu.vram_total_mb,
         "vram_percent": format!("{:.0}", gpu.vram_percent()),
         "name": &gpu.name,
+        "ram_used_gb": format!("{ram_used_gb:.1}"),
+        "ram_total_gb": format!("{ram_total_gb:.1}"),
+        "ram_available_gb": format!("{ram_available_gb:.1}"),
+        "ram_percent": format!("{ram_percent:02.0}"),
     });
     crate::template::render(format, ctx).unwrap_or_default()
 }
@@ -202,57 +221,101 @@ mod tests {
     #[test]
     fn format_label_replaces_percent() {
         let gpu = gpu_data(45.7, Some(55.0), 2048, 8192);
-        let result = format_label("{{ percent }}%", &gpu);
+        let result = format_label("{{ percent }}%", &gpu, None);
         assert_eq!(result, "46%");
     }
 
     #[test]
     fn format_label_percent_pads_single_digits() {
         let gpu = gpu_data(5.2, Some(55.0), 2048, 8192);
-        let result = format_label("{{ percent }}", &gpu);
+        let result = format_label("{{ percent }}", &gpu, None);
         assert_eq!(result, "05");
     }
 
     #[test]
     fn format_label_replaces_temp_c() {
         let gpu = gpu_data(50.0, Some(72.5), 2048, 8192);
-        let result = format_label("{{ temp_c }}°C", &gpu);
+        let result = format_label("{{ temp_c }}°C", &gpu, None);
         assert_eq!(result, "72°C");
     }
 
     #[test]
     fn format_label_replaces_vram() {
         let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
-        let result = format_label("{{ vram_used_mb }}/{{ vram_total_mb }}MB", &gpu);
+        let result = format_label("{{ vram_used_mb }}/{{ vram_total_mb }}MB", &gpu, None);
         assert_eq!(result, "2048/8192MB");
     }
 
     #[test]
     fn format_label_replaces_vram_percent() {
         let gpu = gpu_data(50.0, Some(55.0), 4096, 8192);
-        let result = format_label("{{ vram_percent }}%", &gpu);
+        let result = format_label("{{ vram_percent }}%", &gpu, None);
         assert_eq!(result, "50%");
     }
 
     #[test]
     fn format_label_replaces_name() {
         let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
-        let result = format_label("{{ name }}", &gpu);
+        let result = format_label("{{ name }}", &gpu, None);
         assert_eq!(result, "Test GPU");
     }
 
     #[test]
     fn format_label_with_no_temp_uses_zero() {
         let gpu = gpu_data(50.0, None, 2048, 8192);
-        let result = format_label("{{ temp_c }}°C", &gpu);
+        let result = format_label("{{ temp_c }}°C", &gpu, None);
         assert_eq!(result, "00°C");
     }
 
     #[test]
     fn format_label_multiple_placeholders() {
         let gpu = gpu_data(75.0, Some(65.0), 4096, 8192);
-        let result = format_label("{{ percent }}% {{ temp_c }}°C {{ vram_percent }}%V", &gpu);
+        let result =
+            format_label("{{ percent }}% {{ temp_c }}°C {{ vram_percent }}%V", &gpu, None);
         assert_eq!(result, "75% 65°C 50%V");
+    }
+
+    #[test]
+    fn format_label_ram_placeholders() {
+        let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
+        let mem = MemoryData {
+            used_bytes: 11_063_328_768,  // ~10.3 GB
+            total_bytes: 17_179_869_184, // 16.0 GB
+            available_bytes: 6_116_540_416,
+            usage_percent: 64.4,
+            swap_total_bytes: 0,
+            swap_used_bytes: 0,
+            swap_percent: 0.0,
+        };
+        let result = format_label(
+            "{{ ram_used_gb }}/{{ ram_total_gb }}GB",
+            &gpu,
+            Some(&mem),
+        );
+        assert_eq!(result, "10.3/16.0GB");
+    }
+
+    #[test]
+    fn format_label_ram_percent() {
+        let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
+        let mem = MemoryData {
+            used_bytes: 11_063_328_768,
+            total_bytes: 17_179_869_184,
+            available_bytes: 6_116_540_416,
+            usage_percent: 5.2,
+            swap_total_bytes: 0,
+            swap_used_bytes: 0,
+            swap_percent: 0.0,
+        };
+        let result = format_label("{{ ram_percent }}%", &gpu, Some(&mem));
+        assert_eq!(result, "05%");
+    }
+
+    #[test]
+    fn format_label_ram_none_uses_zero() {
+        let gpu = gpu_data(50.0, Some(55.0), 2048, 8192);
+        let result = format_label("{{ ram_used_gb }}/{{ ram_total_gb }}GB", &gpu, None);
+        assert_eq!(result, "0.0/0.0GB");
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/messages.rs
@@ -1,0 +1,29 @@
+use std::{rc::Rc, sync::Arc};
+
+use wayle_config::{ConfigService, schemas::styling::ThresholdColors};
+use wayle_widgets::prelude::BarSettings;
+
+use crate::shell::bar::dropdowns::DropdownRegistry;
+
+pub(crate) struct GpuInit {
+    pub settings: BarSettings,
+    pub config: Arc<ConfigService>,
+    pub dropdowns: Rc<DropdownRegistry>,
+}
+
+#[derive(Debug)]
+pub(crate) enum GpuMsg {
+    LeftClick,
+    RightClick,
+    MiddleClick,
+    ScrollUp,
+    ScrollDown,
+}
+
+#[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum GpuCmd {
+    UpdateLabel(String),
+    UpdateIcon(String),
+    UpdateThresholdColors(ThresholdColors),
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/mod.rs
@@ -8,6 +8,7 @@ use std::{rc::Rc, sync::Arc};
 use gtk::prelude::*;
 use relm4::prelude::*;
 use wayle_config::{ConfigProperty, ConfigService, schemas::styling::CssToken};
+use wayle_sysinfo::SysinfoService;
 use wayle_widgets::prelude::{
     BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
 };
@@ -22,6 +23,8 @@ pub(crate) struct GpuModule {
     bar_button: Controller<BarButton>,
     config: Arc<ConfigService>,
     dropdowns: Rc<DropdownRegistry>,
+    #[allow(dead_code)]
+    sysinfo: Arc<SysinfoService>,
 }
 
 #[relm4::component(pub(crate))]
@@ -60,7 +63,8 @@ impl Component for GpuModule {
             helpers::GpuVendor::Amd => helpers::read_amd(card_index),
             helpers::GpuVendor::Unknown => helpers::GpuData::default(),
         };
-        let initial_label = helpers::format_label(&gpu_config.format.get(), &initial_gpu);
+        let mem = init.sysinfo.memory.get();
+        let initial_label = helpers::format_label(&gpu_config.format.get(), &initial_gpu, Some(&mem));
 
         let bar_button = BarButton::builder()
             .launch(BarButtonInit {
@@ -92,12 +96,20 @@ impl Component for GpuModule {
                 BarButtonOutput::ScrollDown => GpuMsg::ScrollDown,
             });
 
-        watchers::spawn_watchers(&sender, gpu_config, vendor, card_index, nvml.map(Arc::new));
+        watchers::spawn_watchers(
+            &sender,
+            gpu_config,
+            vendor,
+            card_index,
+            nvml.map(Arc::new),
+            init.sysinfo.clone(),
+        );
 
         let model = Self {
             bar_button,
             config: init.config,
             dropdowns: init.dropdowns,
+            sysinfo: init.sysinfo,
         };
         let bar_button = model.bar_button.widget();
         let widgets = view_output!();

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/mod.rs
@@ -1,0 +1,136 @@
+mod factory;
+mod helpers;
+mod messages;
+mod watchers;
+
+use std::{rc::Rc, sync::Arc};
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+use wayle_config::{ConfigProperty, ConfigService, schemas::styling::CssToken};
+use wayle_widgets::prelude::{
+    BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
+};
+
+pub(crate) use self::{
+    factory::Factory,
+    messages::{GpuCmd, GpuInit, GpuMsg},
+};
+use crate::shell::bar::dropdowns::{self, DropdownRegistry};
+
+pub(crate) struct GpuModule {
+    bar_button: Controller<BarButton>,
+    config: Arc<ConfigService>,
+    dropdowns: Rc<DropdownRegistry>,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for GpuModule {
+    type Init = GpuInit;
+    type Input = GpuMsg;
+    type Output = ();
+    type CommandOutput = GpuCmd;
+
+    view! {
+        gtk::Box {
+            add_css_class: "gpu",
+
+            #[local_ref]
+            bar_button -> gtk::MenuButton {},
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let config = init.config.config();
+        let gpu_config = &config.modules.gpu;
+
+        let nvml = helpers::init_nvml();
+        let vendor = helpers::detect_vendor(&gpu_config.vendor.get(), &nvml);
+        let card_index = gpu_config.card_index.get();
+
+        let initial_gpu = match vendor {
+            helpers::GpuVendor::Nvidia => nvml
+                .as_ref()
+                .map(|n| helpers::read_nvidia(n, card_index))
+                .unwrap_or_default(),
+            helpers::GpuVendor::Amd => helpers::read_amd(card_index),
+            helpers::GpuVendor::Unknown => helpers::GpuData::default(),
+        };
+        let initial_label = helpers::format_label(&gpu_config.format.get(), &initial_gpu);
+
+        let bar_button = BarButton::builder()
+            .launch(BarButtonInit {
+                icon: gpu_config.icon_name.get().clone(),
+                label: initial_label,
+                tooltip: None,
+                colors: BarButtonColors {
+                    icon_color: gpu_config.icon_color.clone(),
+                    label_color: gpu_config.label_color.clone(),
+                    icon_background: gpu_config.icon_bg_color.clone(),
+                    button_background: gpu_config.button_bg_color.clone(),
+                    border_color: gpu_config.border_color.clone(),
+                    auto_icon_color: CssToken::Green,
+                },
+                behavior: BarButtonBehavior {
+                    label_max_chars: gpu_config.label_max_length.clone(),
+                    show_icon: gpu_config.icon_show.clone(),
+                    show_label: gpu_config.label_show.clone(),
+                    show_border: gpu_config.border_show.clone(),
+                    visible: ConfigProperty::new(true),
+                },
+                settings: init.settings,
+            })
+            .forward(sender.input_sender(), |output| match output {
+                BarButtonOutput::LeftClick => GpuMsg::LeftClick,
+                BarButtonOutput::RightClick => GpuMsg::RightClick,
+                BarButtonOutput::MiddleClick => GpuMsg::MiddleClick,
+                BarButtonOutput::ScrollUp => GpuMsg::ScrollUp,
+                BarButtonOutput::ScrollDown => GpuMsg::ScrollDown,
+            });
+
+        watchers::spawn_watchers(&sender, gpu_config, vendor, card_index, nvml.map(Arc::new));
+
+        let model = Self {
+            bar_button,
+            config: init.config,
+            dropdowns: init.dropdowns,
+        };
+        let bar_button = model.bar_button.widget();
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>, _root: &Self::Root) {
+        let gpu_config = &self.config.config().modules.gpu;
+
+        let action = match msg {
+            GpuMsg::LeftClick => gpu_config.left_click.get(),
+            GpuMsg::RightClick => gpu_config.right_click.get(),
+            GpuMsg::MiddleClick => gpu_config.middle_click.get(),
+            GpuMsg::ScrollUp => gpu_config.scroll_up.get(),
+            GpuMsg::ScrollDown => gpu_config.scroll_down.get(),
+        };
+
+        dropdowns::dispatch_click(&action, &self.dropdowns, &self.bar_button);
+    }
+
+    fn update_cmd(&mut self, msg: GpuCmd, _sender: ComponentSender<Self>, _root: &Self::Root) {
+        match msg {
+            GpuCmd::UpdateLabel(label) => {
+                self.bar_button.emit(BarButtonInput::SetLabel(label));
+            }
+            GpuCmd::UpdateIcon(icon) => {
+                self.bar_button.emit(BarButtonInput::SetIcon(icon));
+            }
+            GpuCmd::UpdateThresholdColors(colors) => {
+                self.bar_button
+                    .emit(BarButtonInput::SetThresholdColors(colors));
+            }
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/watchers.rs
@@ -1,0 +1,83 @@
+use std::{sync::Arc, time::Duration};
+
+use nvml_wrapper::Nvml;
+use relm4::ComponentSender;
+use wayle_config::schemas::{modules::GpuConfig, styling::evaluate_thresholds};
+use wayle_widgets::watch;
+
+use super::{
+    GpuModule,
+    helpers::{self, GpuData, GpuVendor, format_label},
+    messages::GpuCmd,
+};
+
+pub(super) fn spawn_watchers(
+    sender: &ComponentSender<GpuModule>,
+    config: &GpuConfig,
+    vendor: GpuVendor,
+    card_index: u32,
+    nvml: Option<Arc<Nvml>>,
+) {
+    let format = config.format.clone();
+    let thresholds = config.thresholds.clone();
+    let poll_interval = config.poll_interval_ms.clone();
+
+    // Poll GPU data on interval
+    let format_poll = format.clone();
+    let thresholds_poll = thresholds.clone();
+    let poll_ms = poll_interval.clone();
+    let nvml_poll = nvml.clone();
+    sender.command(move |out, shutdown| {
+        shutdown
+            .register(async move {
+                loop {
+                    let gpu = poll_gpu(vendor, card_index, &nvml_poll);
+                    let label = format_label(&format_poll.get(), &gpu);
+                    let _ = out.send(GpuCmd::UpdateLabel(label));
+
+                    let colors =
+                        evaluate_thresholds(gpu.usage_percent as f64, &thresholds_poll.get());
+                    let _ = out.send(GpuCmd::UpdateThresholdColors(colors));
+
+                    let interval = Duration::from_millis(poll_ms.get());
+                    tokio::time::sleep(interval).await;
+                }
+            })
+            .drop_on_shutdown()
+    });
+
+    // Watch format changes
+    let format_watch = format.clone();
+    let nvml_fmt = nvml.clone();
+    watch!(sender, [format_watch.watch()], |out| {
+        let gpu = poll_gpu(vendor, card_index, &nvml_fmt);
+        let label = format_label(&format_watch.get(), &gpu);
+        let _ = out.send(GpuCmd::UpdateLabel(label));
+    });
+
+    // Watch icon changes
+    let icon_name = config.icon_name.clone();
+    watch!(sender, [icon_name.watch()], |out| {
+        let _ = out.send(GpuCmd::UpdateIcon(icon_name.get().clone()));
+    });
+
+    // Watch threshold changes
+    let thresholds_watch = thresholds.clone();
+    let nvml_thr = nvml.clone();
+    watch!(sender, [thresholds_watch.watch()], |out| {
+        let gpu = poll_gpu(vendor, card_index, &nvml_thr);
+        let colors = evaluate_thresholds(gpu.usage_percent as f64, &thresholds_watch.get());
+        let _ = out.send(GpuCmd::UpdateThresholdColors(colors));
+    });
+}
+
+fn poll_gpu(vendor: GpuVendor, card_index: u32, nvml: &Option<Arc<Nvml>>) -> GpuData {
+    match vendor {
+        GpuVendor::Nvidia => nvml
+            .as_ref()
+            .map(|n| helpers::read_nvidia(n, card_index))
+            .unwrap_or_default(),
+        GpuVendor::Amd => helpers::read_amd(card_index),
+        GpuVendor::Unknown => GpuData::default(),
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/gpu/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/gpu/watchers.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, time::Duration};
 use nvml_wrapper::Nvml;
 use relm4::ComponentSender;
 use wayle_config::schemas::{modules::GpuConfig, styling::evaluate_thresholds};
+use wayle_sysinfo::SysinfoService;
 use wayle_widgets::watch;
 
 use super::{
@@ -17,6 +18,7 @@ pub(super) fn spawn_watchers(
     vendor: GpuVendor,
     card_index: u32,
     nvml: Option<Arc<Nvml>>,
+    sysinfo: Arc<SysinfoService>,
 ) {
     let format = config.format.clone();
     let thresholds = config.thresholds.clone();
@@ -27,12 +29,14 @@ pub(super) fn spawn_watchers(
     let thresholds_poll = thresholds.clone();
     let poll_ms = poll_interval.clone();
     let nvml_poll = nvml.clone();
+    let sysinfo_poll = sysinfo.clone();
     sender.command(move |out, shutdown| {
         shutdown
             .register(async move {
                 loop {
                     let gpu = poll_gpu(vendor, card_index, &nvml_poll);
-                    let label = format_label(&format_poll.get(), &gpu);
+                    let mem = sysinfo_poll.memory.get();
+                    let label = format_label(&format_poll.get(), &gpu, Some(&mem));
                     let _ = out.send(GpuCmd::UpdateLabel(label));
 
                     let colors =
@@ -49,9 +53,11 @@ pub(super) fn spawn_watchers(
     // Watch format changes
     let format_watch = format.clone();
     let nvml_fmt = nvml.clone();
+    let sysinfo_fmt = sysinfo.clone();
     watch!(sender, [format_watch.watch()], |out| {
         let gpu = poll_gpu(vendor, card_index, &nvml_fmt);
-        let label = format_label(&format_watch.get(), &gpu);
+        let mem = sysinfo_fmt.memory.get();
+        let label = format_label(&format_watch.get(), &gpu, Some(&mem));
         let _ = out.send(GpuCmd::UpdateLabel(label));
     });
 
@@ -68,6 +74,17 @@ pub(super) fn spawn_watchers(
         let gpu = poll_gpu(vendor, card_index, &nvml_thr);
         let colors = evaluate_thresholds(gpu.usage_percent as f64, &thresholds_watch.get());
         let _ = out.send(GpuCmd::UpdateThresholdColors(colors));
+    });
+
+    // Watch memory changes — re-render label when RAM data updates
+    let format_mem = format.clone();
+    let nvml_mem = nvml.clone();
+    let sysinfo_mem = sysinfo.clone();
+    watch!(sender, [sysinfo_mem.memory.watch()], |out| {
+        let gpu = poll_gpu(vendor, card_index, &nvml_mem);
+        let mem = sysinfo_mem.memory.get();
+        let label = format_label(&format_mem.get(), &gpu, Some(&mem));
+        let _ = out.send(GpuCmd::UpdateLabel(label));
     });
 }
 

--- a/crates/wayle-shell/src/shell/bar/modules/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mod.rs
@@ -6,6 +6,7 @@ mod compositor;
 mod cpu;
 mod custom;
 mod dashboard;
+mod gpu;
 mod hyprland_workspaces;
 mod hyprsunset;
 mod idle_inhibit;
@@ -63,6 +64,7 @@ register_modules! {
     Clock => clock::Factory,
     Cpu => cpu::Factory,
     Dashboard => dashboard::Factory,
+    Gpu => gpu::Factory,
     HyprlandWorkspaces => hyprland_workspaces::Factory,
     Hyprsunset => hyprsunset::Factory,
     IdleInhibit => idle_inhibit::Factory,

--- a/crates/wayle-shell/src/shell/bar/modules/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mod.rs
@@ -23,7 +23,7 @@ mod registry;
 mod separator;
 mod storage;
 mod systray;
-mod updates;
+pub(crate) mod updates;
 mod volume;
 pub(crate) mod weather;
 mod window_title;

--- a/crates/wayle-shell/src/shell/bar/modules/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mod.rs
@@ -23,6 +23,7 @@ mod registry;
 mod separator;
 mod storage;
 mod systray;
+mod updates;
 mod volume;
 pub(crate) mod weather;
 mod window_title;
@@ -80,6 +81,7 @@ register_modules! {
     Separator => separator::Factory,
     Storage => storage::Factory,
     Systray => systray::Factory,
+    Updates => updates::Factory,
     Volume => volume::Factory,
     Weather => weather::Factory,
     WindowTitle => window_title::Factory,

--- a/crates/wayle-shell/src/shell/bar/modules/updates/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/factory.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use relm4::prelude::*;
 use wayle_widgets::prelude::BarSettings;
 
-use super::{GpuInit, GpuModule};
+use super::{UpdatesInit, UpdatesModule};
 use crate::shell::{
     bar::{
         dropdowns::DropdownRegistry,
@@ -21,13 +21,12 @@ impl ModuleFactory for Factory {
         dropdowns: &Rc<DropdownRegistry>,
         class: Option<String>,
     ) -> Option<ModuleInstance> {
-        let init = GpuInit {
+        let init = UpdatesInit {
             settings: settings.clone(),
-            sysinfo: services.sysinfo.clone(),
             config: services.config.clone(),
             dropdowns: dropdowns.clone(),
         };
-        let controller = dynamic_controller(GpuModule::builder().launch(init).detach());
+        let controller = dynamic_controller(UpdatesModule::builder().launch(init).detach());
         Some(ModuleInstance { controller, class })
     }
 }

--- a/crates/wayle-shell/src/shell/bar/modules/updates/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/helpers.rs
@@ -1,4 +1,9 @@
 use serde_json::json;
+use std::sync::LazyLock;
+use tokio::sync::Notify;
+
+/// Signal for the bar module to re-poll update counts immediately.
+pub(crate) static REFRESH_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
 /// Counts of available package updates.
 #[derive(Debug, Clone, Default)]

--- a/crates/wayle-shell/src/shell/bar/modules/updates/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/helpers.rs
@@ -1,0 +1,99 @@
+use serde_json::json;
+
+/// Counts of available package updates.
+#[derive(Debug, Clone, Default)]
+pub(super) struct UpdateCounts {
+    pub pacman: u32,
+    pub aur: u32,
+    pub flatpak: u32,
+}
+
+impl UpdateCounts {
+    pub fn total(&self) -> u32 {
+        self.pacman + self.aur + self.flatpak
+    }
+}
+
+/// Run a shell command and parse the trimmed stdout as a u32 count.
+pub(super) async fn run_count_command(command: &str) -> u32 {
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .output()
+        .await;
+
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let trimmed = stdout.trim();
+            let count = trimmed.parse::<u32>().unwrap_or(0);
+            tracing::debug!(
+                "updates cmd `{}` → stdout={:?} stderr={:?} count={}",
+                command, trimmed, stderr.trim(), count
+            );
+            count
+        }
+        Err(e) => {
+            tracing::warn!("updates check command failed: {e}");
+            0
+        }
+    }
+}
+
+/// Check for updates by running the configured commands.
+pub(super) async fn check_updates(
+    official_cmd: &str,
+    aur_cmd: &str,
+    flatpak_cmd: &str,
+) -> UpdateCounts {
+    let (pacman, aur, flatpak) = tokio::join!(
+        run_count_command(official_cmd),
+        run_count_command(aur_cmd),
+        run_count_command(flatpak_cmd),
+    );
+    UpdateCounts { pacman, aur, flatpak }
+}
+
+/// Format the bar label using Jinja2 template syntax.
+pub(super) fn format_label(format: &str, counts: &UpdateCounts) -> String {
+    let ctx = json!({
+        "pacman": counts.pacman,
+        "aur": counts.aur,
+        "flatpak": counts.flatpak,
+        "total": counts.total(),
+    });
+    crate::template::render(format, ctx).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_label_total() {
+        let counts = UpdateCounts { pacman: 145, aur: 24, flatpak: 3 };
+        let result = format_label("{{ total }}", &counts);
+        assert_eq!(result, "172");
+    }
+
+    #[test]
+    fn format_label_breakdown() {
+        let counts = UpdateCounts { pacman: 145, aur: 24, flatpak: 3 };
+        let result = format_label("pac:{{ pacman }} aur:{{ aur }} fp:{{ flatpak }}", &counts);
+        assert_eq!(result, "pac:145 aur:24 fp:3");
+    }
+
+    #[test]
+    fn format_label_zero() {
+        let counts = UpdateCounts::default();
+        let result = format_label("{{ total }}", &counts);
+        assert_eq!(result, "0");
+    }
+
+    #[test]
+    fn update_counts_total() {
+        let counts = UpdateCounts { pacman: 100, aur: 50, flatpak: 5 };
+        assert_eq!(counts.total(), 155);
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/updates/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/messages.rs
@@ -1,20 +1,18 @@
 use std::{rc::Rc, sync::Arc};
 
 use wayle_config::{ConfigService, schemas::styling::ThresholdColors};
-use wayle_sysinfo::SysinfoService;
 use wayle_widgets::prelude::BarSettings;
 
 use crate::shell::bar::dropdowns::DropdownRegistry;
 
-pub(crate) struct GpuInit {
+pub(crate) struct UpdatesInit {
     pub settings: BarSettings,
-    pub sysinfo: Arc<SysinfoService>,
     pub config: Arc<ConfigService>,
     pub dropdowns: Rc<DropdownRegistry>,
 }
 
 #[derive(Debug)]
-pub(crate) enum GpuMsg {
+pub(crate) enum UpdatesMsg {
     LeftClick,
     RightClick,
     MiddleClick,
@@ -24,8 +22,9 @@ pub(crate) enum GpuMsg {
 
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
-pub(crate) enum GpuCmd {
+pub(crate) enum UpdatesCmd {
     UpdateLabel(String),
     UpdateIcon(String),
     UpdateThresholdColors(ThresholdColors),
+    UpdateVisibility(bool),
 }

--- a/crates/wayle-shell/src/shell/bar/modules/updates/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/mod.rs
@@ -1,5 +1,5 @@
 mod factory;
-mod helpers;
+pub(crate) mod helpers;
 mod messages;
 mod watchers;
 

--- a/crates/wayle-shell/src/shell/bar/modules/updates/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/mod.rs
@@ -1,0 +1,137 @@
+mod factory;
+mod helpers;
+mod messages;
+mod watchers;
+
+use std::{rc::Rc, sync::Arc};
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+use wayle_config::{ConfigProperty, ConfigService, schemas::styling::CssToken};
+use wayle_widgets::prelude::{
+    BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
+};
+
+pub(crate) use self::{
+    factory::Factory,
+    messages::{UpdatesCmd, UpdatesInit, UpdatesMsg},
+};
+use crate::shell::bar::dropdowns::{self, DropdownRegistry};
+
+pub(crate) struct UpdatesModule {
+    bar_button: Controller<BarButton>,
+    config: Arc<ConfigService>,
+    dropdowns: Rc<DropdownRegistry>,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for UpdatesModule {
+    type Init = UpdatesInit;
+    type Input = UpdatesMsg;
+    type Output = ();
+    type CommandOutput = UpdatesCmd;
+
+    view! {
+        gtk::Box {
+            add_css_class: "updates",
+
+            #[local_ref]
+            bar_button -> gtk::MenuButton {},
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let config = init.config.config();
+        let updates_config = &config.modules.updates;
+
+        let initial_label = String::from("...");
+
+        let bar_button = BarButton::builder()
+            .launch(BarButtonInit {
+                icon: updates_config.icon_name.get().clone(),
+                label: initial_label,
+                tooltip: None,
+                colors: BarButtonColors {
+                    icon_color: updates_config.icon_color.clone(),
+                    label_color: updates_config.label_color.clone(),
+                    icon_background: updates_config.icon_bg_color.clone(),
+                    button_background: updates_config.button_bg_color.clone(),
+                    border_color: updates_config.border_color.clone(),
+                    auto_icon_color: CssToken::Blue,
+                },
+                behavior: BarButtonBehavior {
+                    label_max_chars: updates_config.label_max_length.clone(),
+                    show_icon: updates_config.icon_show.clone(),
+                    show_label: updates_config.label_show.clone(),
+                    show_border: updates_config.border_show.clone(),
+                    visible: ConfigProperty::new(true),
+                },
+                settings: init.settings,
+            })
+            .forward(sender.input_sender(), |output| match output {
+                BarButtonOutput::LeftClick => UpdatesMsg::LeftClick,
+                BarButtonOutput::RightClick => UpdatesMsg::RightClick,
+                BarButtonOutput::MiddleClick => UpdatesMsg::MiddleClick,
+                BarButtonOutput::ScrollUp => UpdatesMsg::ScrollUp,
+                BarButtonOutput::ScrollDown => UpdatesMsg::ScrollDown,
+            });
+
+        // Hide initially if hide-if-zero is set (will show when updates found)
+        if updates_config.hide_if_zero.get() {
+            root.set_visible(false);
+        }
+
+        watchers::spawn_watchers(&sender, updates_config);
+
+        let model = Self {
+            bar_button,
+            config: init.config,
+            dropdowns: init.dropdowns,
+        };
+        let bar_button = model.bar_button.widget();
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>, _root: &Self::Root) {
+        let updates_config = &self.config.config().modules.updates;
+
+        let action = match msg {
+            UpdatesMsg::LeftClick => updates_config.left_click.get(),
+            UpdatesMsg::RightClick => updates_config.right_click.get(),
+            UpdatesMsg::MiddleClick => updates_config.middle_click.get(),
+            UpdatesMsg::ScrollUp => updates_config.scroll_up.get(),
+            UpdatesMsg::ScrollDown => updates_config.scroll_down.get(),
+        };
+
+        dropdowns::dispatch_click(&action, &self.dropdowns, &self.bar_button);
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: UpdatesCmd,
+        _sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+        match msg {
+            UpdatesCmd::UpdateLabel(label) => {
+                self.bar_button.emit(BarButtonInput::SetLabel(label));
+            }
+            UpdatesCmd::UpdateIcon(icon) => {
+                self.bar_button.emit(BarButtonInput::SetIcon(icon));
+            }
+            UpdatesCmd::UpdateThresholdColors(colors) => {
+                self.bar_button
+                    .emit(BarButtonInput::SetThresholdColors(colors));
+            }
+            UpdatesCmd::UpdateVisibility(visible) => {
+                root.set_visible(visible);
+            }
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/updates/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/watchers.rs
@@ -67,7 +67,12 @@ pub(super) fn spawn_watchers(
                     first_run = false;
 
                     let interval = Duration::from_millis(poll_ms.get());
-                    tokio::time::sleep(interval).await;
+                    tokio::select! {
+                        _ = tokio::time::sleep(interval) => {},
+                        _ = helpers::REFRESH_NOTIFY.notified() => {
+                            tracing::debug!("bar updates: refresh signal received, re-polling");
+                        },
+                    }
                 }
             })
             .drop_on_shutdown()

--- a/crates/wayle-shell/src/shell/bar/modules/updates/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/updates/watchers.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use relm4::ComponentSender;
+use wayle_config::schemas::{modules::UpdatesConfig, styling::evaluate_thresholds};
+use wayle_widgets::watch;
+
+use super::{
+    UpdatesModule,
+    helpers::{self, UpdateCounts},
+    messages::UpdatesCmd,
+};
+
+pub(super) fn spawn_watchers(
+    sender: &ComponentSender<UpdatesModule>,
+    config: &UpdatesConfig,
+) {
+    let format = config.format.clone();
+    let thresholds = config.thresholds.clone();
+    let poll_interval = config.poll_interval_ms.clone();
+    let official_cmd = config.check_official_command.clone();
+    let aur_cmd = config.check_aur_command.clone();
+    let flatpak_cmd = config.check_flatpak_command.clone();
+    let hide_if_zero = config.hide_if_zero.clone();
+
+    // Poll for updates on interval
+    let format_poll = format.clone();
+    let thresholds_poll = thresholds.clone();
+    let poll_ms = poll_interval.clone();
+    let official_poll = official_cmd.clone();
+    let aur_poll = aur_cmd.clone();
+    let flatpak_poll = flatpak_cmd.clone();
+    let hide_poll = hide_if_zero.clone();
+    sender.command(move |out, shutdown| {
+        shutdown
+            .register(async move {
+                // Wait for network to be ready on login before first check
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                let mut first_run = true;
+                loop {
+                    let counts = helpers::check_updates(
+                        &official_poll.get(),
+                        &aur_poll.get(),
+                        &flatpak_poll.get(),
+                    )
+                    .await;
+
+                    let label = helpers::format_label(&format_poll.get(), &counts);
+                    let _ = out.send(UpdatesCmd::UpdateLabel(label));
+
+                    let colors =
+                        evaluate_thresholds(counts.total() as f64, &thresholds_poll.get());
+                    let _ = out.send(UpdatesCmd::UpdateThresholdColors(colors));
+
+                    if hide_poll.get() {
+                        let _ = out.send(UpdatesCmd::UpdateVisibility(counts.total() > 0));
+                    }
+
+                    // On first run, if official returned 0 but others didn't,
+                    // retry quickly (checkupdates may have failed due to network)
+                    if first_run && counts.pacman == 0 && (counts.aur > 0 || counts.flatpak > 0) {
+                        first_run = false;
+                        tracing::debug!("official count was 0 on first run, retrying in 30s");
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        continue;
+                    }
+                    first_run = false;
+
+                    let interval = Duration::from_millis(poll_ms.get());
+                    tokio::time::sleep(interval).await;
+                }
+            })
+            .drop_on_shutdown()
+    });
+
+    // Watch format changes
+    let format_watch = format.clone();
+    watch!(sender, [format_watch.watch()], |out| {
+        let label = helpers::format_label(&format_watch.get(), &UpdateCounts::default());
+        let _ = out.send(UpdatesCmd::UpdateLabel(label));
+    });
+
+    // Watch icon changes
+    let icon_name = config.icon_name.clone();
+    watch!(sender, [icon_name.watch()], |out| {
+        let _ = out.send(UpdatesCmd::UpdateIcon(icon_name.get().clone()));
+    });
+
+    // Watch threshold changes
+    let thresholds_watch = thresholds.clone();
+    watch!(sender, [thresholds_watch.watch()], |out| {
+        let colors = evaluate_thresholds(0.0, &thresholds_watch.get());
+        let _ = out.send(UpdatesCmd::UpdateThresholdColors(colors));
+    });
+}

--- a/crates/wayle-styling/scss/modules/_index.scss
+++ b/crates/wayle-styling/scss/modules/_index.scss
@@ -11,4 +11,5 @@
 @import "media_dropdown";
 @import "network_dropdown";
 @import "notification_dropdown";
+@import "sysinfo_dropdown";
 @import "weather_dropdown";

--- a/crates/wayle-styling/scss/modules/sysinfo_dropdown/_index.scss
+++ b/crates/wayle-styling/scss/modules/sysinfo_dropdown/_index.scss
@@ -1,0 +1,1 @@
+@import "sysinfo";

--- a/crates/wayle-styling/scss/modules/sysinfo_dropdown/_sysinfo.scss
+++ b/crates/wayle-styling/scss/modules/sysinfo_dropdown/_sysinfo.scss
@@ -1,0 +1,97 @@
+.sysinfo-dropdown {
+    > contents > .dropdown {
+        min-width: 0;
+    }
+
+    .dropdown-content {
+        border-spacing: var(--space-sm);
+    }
+
+    // ── Cards ──────────────────────────────────────────
+    .sysinfo-card {
+        border-radius: var(--rounding-element);
+        min-width: 0;
+        padding-left: var(--space-md);
+        padding-right: var(--space-md);
+    }
+
+    // ── Card header ───────────────────────────────────
+    .sysinfo-card-header {
+        margin-top: var(--space-sm);
+        margin-bottom: var(--space-xs);
+        border-spacing: var(--space-sm);
+
+        image, label {
+            margin-top: auto;
+            margin-bottom: auto;
+        }
+    }
+
+    .sysinfo-header-icon {
+        color: var(--fg-subtle);
+    }
+
+    .sysinfo-header-label {
+        font-size: var(--text-xs);
+        font-weight: var(--weight-semibold);
+        color: var(--fg-subtle);
+        text-transform: uppercase;
+    }
+
+    // ── Stat rows ─────────────────────────────────────
+    .sysinfo-stat-list {
+        margin-left: var(--space-md);
+        margin-right: var(--space-md);
+        margin-bottom: var(--space-sm);
+    }
+
+    .sysinfo-stat {
+        padding-top: var(--space-xs);
+        padding-bottom: var(--space-xs);
+    }
+
+    .sysinfo-stat-key {
+        font-size: var(--text-sm);
+        font-weight: var(--weight-medium);
+        color: var(--fg-subtle);
+    }
+
+    .sysinfo-stat-val {
+        font-size: var(--text-md);
+        font-weight: var(--weight-semibold);
+        color: var(--fg-default);
+    }
+
+    // ── Action buttons (quick-action tiles) ──────────
+    button.quick-action {
+        padding: var(--space-sm);
+        border-radius: var(--rounding-element);
+        transition: background var(--duration-fast);
+
+        .quick-action-icon {
+            border-radius: var(--rounding-container);
+            background: var(--bg-overlay);
+            padding: var(--space-sm);
+            transition: background var(--duration-fast), color var(--duration-fast);
+
+            image {
+                color: var(--fg-muted);
+            }
+        }
+
+        .quick-action-label {
+            font-size: var(--text-base);
+            font-weight: var(--weight-semibold);
+            color: var(--fg-subtle);
+        }
+
+        &:hover .quick-action-icon {
+            background: var(--accent);
+            image { color: var(--fg-on-accent); }
+        }
+
+        &:hover .quick-action-label {
+            color: var(--fg-default);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a built-in GPU bar module that displays utilization, temperature, and VRAM
- Supports **NVIDIA** (via NVML / `nvml-wrapper`) and **AMD** (via sysfs/hwmon)
- Auto-detects GPU vendor at startup; configurable override via `vendor` field

## NVIDIA support

Uses [`nvml-wrapper`](https://crates.io/crates/nvml-wrapper) (0.12.1) which dynamically loads `libnvidia-ml.so` at runtime. No build-time dependency on the NVIDIA SDK. Gracefully returns `None` on non-NVIDIA systems.

Provides: GPU utilization %, temperature, VRAM used/total, GPU name — all via direct NVML API calls (no process spawning, no text parsing).

## AMD support

Reads from `/sys/class/drm/card<N>/device/`:
- `gpu_busy_percent` — utilization
- `mem_info_vram_used` / `mem_info_vram_total` — VRAM
- `hwmon/*/temp1_input` — temperature (millidegrees)
- `product_name` or `marketing_name` — GPU name

## Configuration

```toml
[modules.gpu]
vendor = "auto"          # "auto", "nvidia", "amd"
card-index = 0           # device index (AMD DRM card or NVIDIA device)
poll-interval-ms = 5000
format = "{{ percent }}%"
icon-name = "ld-gpu-symbolic"

# threshold colors
[[modules.gpu.thresholds]]
above = 70
icon-color = "status-warning"

[[modules.gpu.thresholds]]
above = 90
icon-color = "status-error"
```

### Format placeholders

| Placeholder | Description |
|---|---|
| `{{ percent }}` | GPU usage (00-100, zero-padded) |
| `{{ temp_c }}` | Temperature in Celsius |
| `{{ temp_f }}` | Temperature in Fahrenheit |
| `{{ vram_used_mb }}` | VRAM used (MB) |
| `{{ vram_total_mb }}` | VRAM total (MB) |
| `{{ vram_percent }}` | VRAM usage % |
| `{{ name }}` | GPU model name |

## New files

**wayle-config:**
- `schemas/modules/gpu/mod.rs` — `GpuConfig` with `#[wayle_config(bar_button)]`

**wayle-shell:**
- `bar/modules/gpu/mod.rs` — `GpuModule` component
- `bar/modules/gpu/factory.rs` — `Factory` impl
- `bar/modules/gpu/messages.rs` — `GpuInit`, `GpuMsg`, `GpuCmd`
- `bar/modules/gpu/helpers.rs` — `GpuData`, NVML reader, AMD sysfs reader, format_label (9 unit tests)
- `bar/modules/gpu/watchers.rs` — poll loop + config watchers

## New dependency

- `nvml-wrapper = "0.12.1"` — thin Rust bindings over NVML. Uses `dlopen` at runtime so it doesn't affect compilation or break on non-NVIDIA systems. ~1.7M downloads, actively maintained.

## Testing

- 9 unit tests for `format_label` and `vram_percent` — all passing
- `cargo build` — clean
- `cargo test -p wayle-shell -- gpu` — 9/9 pass